### PR TITLE
Fix bug where RETURN GRAPH was allowed mid-query

### DIFF
--- a/ast/src/main/scala/org/opencypher/v9_0/ast/Query.scala
+++ b/ast/src/main/scala/org/opencypher/v9_0/ast/Query.scala
@@ -84,6 +84,8 @@ case class SingleQuery(clauses: Seq[Clause])(val position: InputPosition) extend
             Some(SemanticError(s"WITH is required between ${clause.name} and ${start.name}", clause.position, start.position))
           case Seq(match1: Match, match2: Match) if match1.optional && !match2.optional =>
             Some(SemanticError(s"${match2.name} cannot follow OPTIONAL ${match1.name} (perhaps use a WITH clause between them)", match2.position, match1.position))
+          case Seq(clause: ReturnGraph, _) =>
+            Some(SemanticError(s"${clause.name} can only be used at the end of the query", clause.position))
           case Seq(clause: Return, _) =>
             Some(SemanticError(s"${clause.name} can only be used at the end of the query", clause.position))
           case Seq(_: UpdateClause, _: UpdateClause) =>

--- a/frontend/src/test/scala/org/opencypher/v9_0/frontend/MultipleGraphClauseSemanticCheckingTest.scala
+++ b/frontend/src/test/scala/org/opencypher/v9_0/frontend/MultipleGraphClauseSemanticCheckingTest.scala
@@ -34,6 +34,20 @@ class MultipleGraphClauseSemanticCheckingTest
 
   implicit val parser: Rule1[Query] = Query
 
+  test("allows both versions of FROM") {
+    parsing(
+      """FROM foo.bar
+        |MATCH (a:Swedish)
+        |CONSTRUCT
+        |   NEW (b COPY OF A:Programmer)
+        |FROM GRAPH bar.foo
+        |MATCH (a:Foo)
+        |RETURN a.name""".stripMargin) shouldVerify { result: SemanticCheckResult =>
+
+      result.errors shouldBe empty
+    }
+  }
+
   test("does not allow RETURN GRAPH in middle of query") {
     parsing(
       """MATCH (a:Swedish)

--- a/frontend/src/test/scala/org/opencypher/v9_0/frontend/MultipleGraphClauseSemanticCheckingTest.scala
+++ b/frontend/src/test/scala/org/opencypher/v9_0/frontend/MultipleGraphClauseSemanticCheckingTest.scala
@@ -34,6 +34,19 @@ class MultipleGraphClauseSemanticCheckingTest
 
   implicit val parser: Rule1[Query] = Query
 
+  test("does not allow RETURN GRAPH in middle of query") {
+    parsing(
+      """MATCH (a:Swedish)
+        |CONSTRUCT
+        |   NEW (b COPY OF A:Programmer)
+        |RETURN GRAPH
+        |MATCH (a:Foo)
+        |RETURN a.name""".stripMargin) shouldVerify { result: SemanticCheckResult =>
+
+      result.errorMessages should equal(Set("RETURN GRAPH can only be used at the end of the query"))
+    }
+  }
+
   test("allows COPY OF Node") {
     parsing(
       """MATCH (a:Swedish)

--- a/parser/src/main/scala/org/opencypher/v9_0/parser/Clauses.scala
+++ b/parser/src/main/scala/org/opencypher/v9_0/parser/Clauses.scala
@@ -40,7 +40,7 @@ trait Clauses extends Parser
   }
 
   def FromGraph: Rule1[ast.FromGraph]= rule("FROM GRAPH") {
-    group(keyword("FROM GRAPH") ~~ QualifiedGraphName ~~>> (ast.FromGraph(_)))
+    group(keyword("FROM") ~~ optional(keyword("GRAPH")) ~~ QualifiedGraphName ~~>> (ast.FromGraph(_)))
   }
 
   def ConstructGraph: Rule1[ast.ConstructGraph] = rule("CONSTRUCT") {

--- a/parser/src/test/scala/org/opencypher/v9_0/parser/MultipleGraphClausesParsingTest.scala
+++ b/parser/src/test/scala/org/opencypher/v9_0/parser/MultipleGraphClausesParsingTest.scala
@@ -170,18 +170,39 @@ class MultipleGraphClausesParsingTest
     yields(ast.ReturnGraph(Some(ast.QualifiedGraphName("union"))))
   }
 
+  // TODO: Causes parser to fail with its unhelpful error message
+  ignore("FROM graph") {
+    yields(ast.FromGraph(ast.QualifiedGraphName(List("graph"))))
+  }
+
+  test("FROM GRAPH graph") {
+    yields(ast.FromGraph(ast.QualifiedGraphName(List("graph"))))
+  }
+
+  test("FROM `graph`") {
+    yields(ast.FromGraph(ast.QualifiedGraphName(List("graph"))))
+  }
+
   test("FROM GRAPH `foo.bar.baz.baz`"){
+    yields(ast.FromGraph(ast.QualifiedGraphName(List("foo.bar.baz.baz"))))
+  }
+
+  test("FROM graph1"){
+    yields(ast.FromGraph(ast.QualifiedGraphName(List("graph1"))))
+  }
+
+  test("FROM `foo.bar.baz.baz`"){
     yields(ast.FromGraph(ast.QualifiedGraphName(List("foo.bar.baz.baz"))))
   }
 
   test("FROM GRAPH `foo.bar`.baz"){
     yields(ast.FromGraph(ast.QualifiedGraphName(List("foo.bar", "baz"))))
   }
-  
+
   test("FROM GRAPH foo.`bar.baz`"){
     yields(ast.FromGraph(ast.QualifiedGraphName(List("foo", "bar.baz"))))
   }
-  
+
   test("FROM GRAPH `foo.bar`.`baz.baz`"){
     yields(ast.FromGraph(ast.QualifiedGraphName(List("foo.bar", "baz.baz"))))
   }
@@ -201,7 +222,7 @@ class MultipleGraphClausesParsingTest
   test("CONSTRUCT ON `foo.bar`.`baz.baz`"){
     yields(ast.ConstructGraph(List.empty, List.empty, List(ast.QualifiedGraphName(List("foo.bar", "baz.baz")))))
   }
-  
+
 
   private val nodePattern = exp.Pattern(List(exp.EveryPath(exp.NodePattern(None, List(), None)(pos))))(pos)
 


### PR DESCRIPTION
Also allows `FROM` to be used without saying `GRAPH` (the long form is also available)

Co-Authored-By: Max Kießling <max.kiessling@neotechnology.com>