### PR TITLE
Remove unsafe rewriter

### DIFF
--- a/rewriting/src/main/scala/org/opencypher/v9_0/rewriting/rewriters/CNFNormalizer.scala
+++ b/rewriting/src/main/scala/org/opencypher/v9_0/rewriting/rewriters/CNFNormalizer.scala
@@ -98,14 +98,14 @@ object simplifyPredicates extends Rewriter {
 
   private val step: Rewriter = Rewriter.lift {
     case Not(Not(exp))                    => exp
-    case p@Ands(exps) if exps.isEmpty     =>  True()(p.position)
-    case p@Ors(exps) if exps.isEmpty      =>  True()(p.position)
+    case p@Ands(exps) if exps.isEmpty     =>  throw new IllegalStateException("we should never get here")
+    case p@Ors(exps) if exps.isEmpty      =>  throw new IllegalStateException("we should never get here")
     case p@Ands(exps) if exps.contains(T) =>
-      val expressions = exps.filterNot(T == _)
-      if (expressions.isEmpty) True()(p.position) else Ands(expressions)(p.position)
+      val nonTrue = exps.filterNot(T == _)
+      if (nonTrue.isEmpty) True()(p.position) else Ands(nonTrue)(p.position)
     case p@Ors(exps) if exps.contains(F)  =>
-      val expressions = exps.filterNot(F == _)
-      if (expressions.isEmpty) False()(p.position) else Ors(expressions)(p.position)
+      val nonFalse = exps.filterNot(F == _)
+      if (nonFalse.isEmpty) False()(p.position) else Ors(nonFalse)(p.position)
     case p@Ors(exps) if exps.contains(T)  => True()(p.position)
     case p@Ands(exps) if exps.contains(F) => False()(p.position)
   }

--- a/rewriting/src/main/scala/org/opencypher/v9_0/rewriting/rewriters/CNFNormalizer.scala
+++ b/rewriting/src/main/scala/org/opencypher/v9_0/rewriting/rewriters/CNFNormalizer.scala
@@ -16,12 +16,11 @@
 package org.opencypher.v9_0.rewriting.rewriters
 
 import org.opencypher.v9_0.expressions._
+import org.opencypher.v9_0.expressions.functions.Exists
+import org.opencypher.v9_0.rewriting.AstRewritingMonitor
 import org.opencypher.v9_0.util.Foldable._
 import org.opencypher.v9_0.util.helpers.fixedPoint
 import org.opencypher.v9_0.util.{Rewriter, bottomUp, inSequence, topDown}
-import org.opencypher.v9_0.expressions._
-import org.opencypher.v9_0.expressions.functions.Exists
-import org.opencypher.v9_0.rewriting.AstRewritingMonitor
 
 
 case class deMorganRewriter()(implicit monitor: AstRewritingMonitor) extends Rewriter {
@@ -99,10 +98,14 @@ object simplifyPredicates extends Rewriter {
 
   private val step: Rewriter = Rewriter.lift {
     case Not(Not(exp))                    => exp
-    case p@Ands(exps) if exps.size == 1   => exps.head
-    case p@Ors(exps) if exps.size == 1    => exps.head
-    case p@Ands(exps) if exps.contains(T) => Ands(exps.filterNot(T == _))(p.position)
-    case p@Ors(exps) if exps.contains(F)  => Ors(exps.filterNot(F == _))(p.position)
+    case p@Ands(exps) if exps.isEmpty     =>  True()(p.position)
+    case p@Ors(exps) if exps.isEmpty      =>  True()(p.position)
+    case p@Ands(exps) if exps.contains(T) =>
+      val expressions = exps.filterNot(T == _)
+      if (expressions.isEmpty) True()(p.position) else Ands(expressions)(p.position)
+    case p@Ors(exps) if exps.contains(F)  =>
+      val expressions = exps.filterNot(F == _)
+      if (expressions.isEmpty) False()(p.position) else Ors(expressions)(p.position)
     case p@Ors(exps) if exps.contains(T)  => True()(p.position)
     case p@Ands(exps) if exps.contains(F) => False()(p.position)
   }

--- a/rewriting/src/test/scala/org/opencypher/v9_0/rewriting/SimplifyPredicatesTest.scala
+++ b/rewriting/src/test/scala/org/opencypher/v9_0/rewriting/SimplifyPredicatesTest.scala
@@ -33,32 +33,4 @@ class SimplifyPredicatesTest extends CypherFunSuite with PredicateTestSupport {
   test("repeated double negation is removed") {
     not(not(not(not(P)))) <=> P
   }
-
-  test("P and P  iff  P") {
-    ands(P, P) <=> P
-  }
-
-  test("P or P  iff  P") {
-    ors(P, P) <=> P
-  }
-
-  test("P or P and P  iff  P") {
-    ors(P, ands(P, P)) <=> P
-  }
-
-  test("not P or not P and not P  iff  not P") {
-    ors(not(P), ands(not(P), not(P))) <=> not(P)
-  }
-
-  test("P or P and P or Q  iff  P or Q") {
-    ands(ors(P, P), ors(P, Q)) <=> ands(P, ors(P, Q))
-  }
-
-  test("ANDS with only one TRUE") {
-    ands(TRUE) <=> TRUE
-  }
-
-  test("ORS with only one FALSE") {
-    ors(FALSE) <=> FALSE
-  }
 }


### PR DESCRIPTION
It is not safe to rewrite `Ands(Set(foo))` to `foo` since the type of `foo`
is not necessarily boolean but could also be e.g. an empty list or pattern.


This has already been done in `neo4j` 3.3-3.4 https://github.com/neo-technology/neo4j/pull/95