### PR TITLE
Remove assertion from wrong place

### DIFF
--- a/frontend/src/main/scala/org/opencypher/v9_0/frontend/phases/AstRewriting.scala
+++ b/frontend/src/main/scala/org/opencypher/v9_0/frontend/phases/AstRewriting.scala
@@ -46,7 +46,6 @@ case class AstRewriting(sequencer: String => RewriterStepSequencer, literalExtra
       noUnnamedPatternElementsInMatch,
       containsNoNodesOfType[NotEquals],
       normalizedEqualsArguments,
-      aggregationsAreIsolated,
       noUnnamedPatternElementsInPatternComprehension
     )
 


### PR DESCRIPTION
`isolateAggregation` has moved to a later phase. It already checks
`aggregationsAreIsolated`. But the earlier phase also checked that
and this too early check is hereby removed.