### PR TITLE
Removes rewriting of n.prop IS NOT NULL --> exists(n.prop)

### DIFF
--- a/rewriting/src/main/scala/org/opencypher/v9_0/rewriting/rewriters/CNFNormalizer.scala
+++ b/rewriting/src/main/scala/org/opencypher/v9_0/rewriting/rewriters/CNFNormalizer.scala
@@ -16,7 +16,6 @@
 package org.opencypher.v9_0.rewriting.rewriters
 
 import org.opencypher.v9_0.expressions._
-import org.opencypher.v9_0.expressions.functions.Exists
 import org.opencypher.v9_0.rewriting.AstRewritingMonitor
 import org.opencypher.v9_0.util.Foldable._
 import org.opencypher.v9_0.util.helpers.fixedPoint
@@ -118,10 +117,6 @@ case object normalizeSargablePredicates extends Rewriter {
   override def apply(that: AnyRef): AnyRef = instance(that)
 
   private val instance: Rewriter = topDown(Rewriter.lift {
-
-    // turn n.prop IS NOT NULL into exists(n.prop)
-    case predicate@IsNotNull(property@Property(_, _)) =>
-      Exists.asInvocation(property)(predicate.position)
 
     // remove not from inequality expressions by negating them
     case Not(inequality: InequalityExpression) =>


### PR DESCRIPTION
Fixes bug related to (invalid) rewriting of `n.prop IS NOT NULL` --> `exists(n.prop)`
Due to the rewrite, when `n` is `null`, `n.prop IS NOT NULL` incorrectly evaluated to `null`, rather than `true`/`false`. 
This is because `IS NULL` & `IS NOT NULL` are binary operators, whereas `Exists` is ternary.
With the changes in this PR `n.prop IS NOT NULL` & `NOT(n.prop IS NULL)` are now equivalent.

This PR is depended on by Neo4j PR https://github.com/neo-technology/neo4j/pull/438.

For updated test coverage see: https://github.com/opencypher/openCypher/pull/327