### PR TITLE
Fix bug in mergePredicates

### DIFF
--- a/rewriting/src/main/scala/org/opencypher/v9_0/rewriting/rewriters/mergeInPredicates.scala
+++ b/rewriting/src/main/scala/org/opencypher/v9_0/rewriting/rewriters/mergeInPredicates.scala
@@ -24,13 +24,13 @@ import org.opencypher.v9_0.util.{Rewriter, bottomUp}
   *
   * Examples:
   * MATCH (n) WHERE n.prop IN [1,2,3] AND [2,3,4] RETURN n.prop
-  * => MATCH (n) WHERE n.prop IN [2,3]
+  * -> MATCH (n) WHERE n.prop IN [2,3]
   *
   * MATCH (n) WHERE n.prop IN [1,2,3] OR [2,3,4] RETURN n.prop
-  * => MATCH (n) WHERE n.prop IN [1,2,3,4]
+  * -> MATCH (n) WHERE n.prop IN [1,2,3,4]
   *
   * MATCH (n) WHERE n.prop IN [1,2,3] AND [4,5,6] RETURN n.prop
-  * => MATCH (n) WHERE FALSE
+  * -> MATCH (n) WHERE FALSE
   *
   * NOTE: this rewriter must be applied before auto parameterization, since after
   * that we are just dealing with opaque parameters.
@@ -41,13 +41,21 @@ case object mergeInPredicates extends Rewriter {
 
   private val inner: Rewriter = bottomUp(Rewriter.lift {
     //Look for a `IN [...] AND a IN [...]` and compute the intersection of lists
-    case and@And(lhs, rhs) =>
+    case and@And(lhs, rhs) if noOrs(lhs) && noOrs(rhs ) =>
       rewriteBinaryOperator(and, (a, b) => a intersect b, (l, r) => and.copy(l, r)(and.position))
     //Look for `a IN [...] OR a IN [...]` and compute union of lists
-    case or@Or(lhs, rhs) =>
+    case or@Or(lhs, rhs) if noAnds(lhs) && noAnds(rhs) =>
       rewriteBinaryOperator(or, (a, b) => a union b,
                             (l, r) => or.copy(l, r)(or.position))
   })
+
+  private def noOrs(expression: Expression):Boolean = !expression.treeExists {
+    case _: Or => true
+  }
+
+  private def noAnds(expression: Expression):Boolean = !expression.treeExists {
+    case _: And => true
+  }
 
   //Takes a binary operator a merge operator and a copy constructor
   //and rewrites the binary operator


### PR DESCRIPTION
The rewriter `mergePredicates` tries to be clever by merging predicates
when possible, e.g.

- `a.prop IN [1,2,3] OR a.prop IN [4]` -> `a.prop IN [1,2,3,4]`
- `a.prop IN [1,2,3] AND a.prop IN [2,3,5]` -> `a.prop IN [2,3]`

However it did the wrong thing and also rewrote expressions like

- `(a.prop IN [1] AND FALSE) OR a.prop in [2]` -> `(a.prop IN [1,2] AND FALSE) AND a.prop IN [1,2]`

which is not equivalent, e.g. `a.prop=1` will now evaluate to `true` instead
of `false`.

Note this is already fixed in neo4j 3.4.