### PR TITLE
Fix bug in semantic analysis with overriding name in WITH .. ORDER BY

### DIFF
--- a/ast/src/main/scala/org/opencypher/v9_0/ast/Clause.scala
+++ b/ast/src/main/scala/org/opencypher/v9_0/ast/Clause.scala
@@ -15,21 +15,21 @@
  */
 package org.opencypher.v9_0.ast
 
-import org.opencypher.v9_0.ast.semantics.SemanticCheckResult.error
-import org.opencypher.v9_0.ast.semantics.SemanticCheckResult.success
 import org.opencypher.v9_0.ast.semantics.Scope
 import org.opencypher.v9_0.ast.semantics.SemanticAnalysisTooling
 import org.opencypher.v9_0.ast.semantics.SemanticCheckResult
+import org.opencypher.v9_0.ast.semantics.SemanticCheckResult.error
+import org.opencypher.v9_0.ast.semantics.SemanticCheckResult.success
 import org.opencypher.v9_0.ast.semantics.SemanticCheckable
 import org.opencypher.v9_0.ast.semantics.SemanticExpressionCheck
 import org.opencypher.v9_0.ast.semantics.SemanticPatternCheck
 import org.opencypher.v9_0.ast.semantics.SemanticState
 import org.opencypher.v9_0.ast.semantics._
 import org.opencypher.v9_0.expressions.Expression.SemanticContext
+import org.opencypher.v9_0.expressions._
+import org.opencypher.v9_0.expressions.functions
 import org.opencypher.v9_0.expressions.functions.Distance
 import org.opencypher.v9_0.expressions.functions.Exists
-import org.opencypher.v9_0.expressions.functions
-import org.opencypher.v9_0.expressions._
 import org.opencypher.v9_0.util.Foldable._
 import org.opencypher.v9_0.util._
 import org.opencypher.v9_0.util.helpers.StringHelper.RichString
@@ -673,10 +673,10 @@ sealed trait ProjectionClause extends HorizonClause {
       val specialReturnItems = createSpecialReturnItems(previousScope, s)
       val specialCheckForOrderByAndWhere =
         specialReturnItems.declareVariables(previousScope) chain
-        orderBy.semanticCheck chain
-        checkSkip chain
-        checkLimit chain where.
-        semanticCheck
+          orderBy.semanticCheck chain
+          checkSkip chain
+          checkLimit chain
+          where.semanticCheck
 
       val orderByAndWhereResult = specialCheckForOrderByAndWhere(s)
       val orderByAndWhereErrors = orderByAndWhereResult.errors

--- a/ast/src/main/scala/org/opencypher/v9_0/ast/Order.scala
+++ b/ast/src/main/scala/org/opencypher/v9_0/ast/Order.scala
@@ -15,10 +15,12 @@
  */
 package org.opencypher.v9_0.ast
 
+import org.opencypher.v9_0.ast.semantics.SemanticCheckable
 import org.opencypher.v9_0.ast.semantics.SemanticExpressionCheck
-import org.opencypher.v9_0.expressions.{Expression, LogicalVariable}
-import org.opencypher.v9_0.util.{ASTNode, InputPosition}
-import org.opencypher.v9_0.ast.semantics.{SemanticCheckable, SemanticExpressionCheck}
+import org.opencypher.v9_0.expressions.Expression
+import org.opencypher.v9_0.expressions.LogicalVariable
+import org.opencypher.v9_0.util.ASTNode
+import org.opencypher.v9_0.util.InputPosition
 
 case class OrderBy(sortItems: Seq[SortItem])(val position: InputPosition) extends ASTNode with SemanticCheckable {
   def semanticCheck = sortItems.semanticCheck

--- a/ast/src/main/scala/org/opencypher/v9_0/ast/semantics/SemanticAnalysisTooling.scala
+++ b/ast/src/main/scala/org/opencypher/v9_0/ast/semantics/SemanticAnalysisTooling.scala
@@ -15,8 +15,10 @@
  */
 package org.opencypher.v9_0.ast.semantics
 
-import org.opencypher.v9_0.expressions.Expression.{DefaultTypeMismatchMessageGenerator, SemanticContext}
-import org.opencypher.v9_0.expressions.{TypeSignature, _}
+import org.opencypher.v9_0.expressions.Expression.DefaultTypeMismatchMessageGenerator
+import org.opencypher.v9_0.expressions.Expression.SemanticContext
+import org.opencypher.v9_0.expressions.TypeSignature
+import org.opencypher.v9_0.expressions._
 import org.opencypher.v9_0.util.InputPosition
 import org.opencypher.v9_0.util.symbols._
 
@@ -165,20 +167,25 @@ trait SemanticAnalysisTooling {
       case e:java.lang.NumberFormatException => false
     }
 
-  def ensureDefined(v:LogicalVariable): (SemanticState) => Either[SemanticError, SemanticState] =
+  def ensureDefined(v:LogicalVariable): SemanticState => Either[SemanticError, SemanticState] =
     (_: SemanticState).ensureVariableDefined(v)
 
-  def declareVariable(v:LogicalVariable, possibleTypes: TypeSpec): (SemanticState) => Either[SemanticError, SemanticState] =
+  def declareVariable(v:LogicalVariable, possibleTypes: TypeSpec): SemanticState => Either[SemanticError, SemanticState] =
     (_: SemanticState).declareVariable(v, possibleTypes)
 
-  def declareVariable(
-                       v:LogicalVariable,
-                       typeGen: TypeGenerator,
-                       positions: Set[InputPosition] = Set.empty
-                     ): (SemanticState) => Either[SemanticError, SemanticState] =
-    (s: SemanticState) => s.declareVariable(v, typeGen(s), positions)
+  /**
+    * @param overriding if `true` then a previous occurrence of that variable is overridden.
+    *                   if `false` then a previous occurrence of that variable leads to an error
+    */
+  def declareVariable(v: LogicalVariable,
+                      typeGen: TypeGenerator,
+                      positions: Set[InputPosition] = Set.empty,
+                      overriding: Boolean = false
+                     ): SemanticState => Either[SemanticError, SemanticState] =
+    (s: SemanticState) =>
+      s.declareVariable(v, typeGen(s), positions, overriding)
 
-  def implicitVariable(v:LogicalVariable, possibleType: CypherType): (SemanticState) => Either[SemanticError, SemanticState] =
+  def implicitVariable(v:LogicalVariable, possibleType: CypherType): SemanticState => Either[SemanticError, SemanticState] =
     (_: SemanticState).implicitVariable(v, possibleType)
 
   def requireMultigraphSupport(msg: String, position: InputPosition): SemanticCheck =


### PR DESCRIPTION
Fixes a bug in semantic analysis that would yield an error on such a
query: `MATCH (n) RETURN n.prop AS n ORDER BY n + 2`

This error was previously hidden by rewriters.