### PR TITLE
Double bug-fixes in pattern comprehesion and missing semantic analysis

### DIFF
--- a/ast/src/main/scala/org/opencypher/v9_0/ast/prettifier/ExpressionStringifier.scala
+++ b/ast/src/main/scala/org/opencypher/v9_0/ast/prettifier/ExpressionStringifier.scala
@@ -99,7 +99,7 @@ case class ExpressionStringifier(extender: Expression => String = e => throw new
         s"all${prettyScope(scope, e)}"
       case NoneIterablePredicate(scope, e) =>
         s"none${prettyScope(scope, e)}"
-      case MapProjection(variable, items, _) =>
+      case MapProjection(variable, items) =>
         val itemsText = items.map {
           case LiteralEntry(k, e) => s"${backtick(k.name)}: ${this.apply(e)}"
           case VariableSelector(v) => this.apply(v)

--- a/ast/src/main/scala/org/opencypher/v9_0/ast/prettifier/ExpressionStringifier.scala
+++ b/ast/src/main/scala/org/opencypher/v9_0/ast/prettifier/ExpressionStringifier.scala
@@ -88,7 +88,7 @@ case class ExpressionStringifier(extender: Expression => String = e => throw new
         val e = s.extractExpression.map(e => " | " + this.apply(e)).getOrElse("")
         val expr = this.apply(expression)
         s"extract($v IN $expr$p$e)"
-      case PatternComprehension(variable, RelationshipsPattern(relChain), predicate, proj, _) =>
+      case PatternComprehension(variable, RelationshipsPattern(relChain), predicate, proj) =>
         val v = variable.map(e => s"${this.apply(e)} = ").getOrElse("")
         val p = predicate.map(e => " WHERE " + this.apply(e)).getOrElse("")
         s"[$v${pattern(relChain)}$p | ${this.apply(proj)}]"

--- a/ast/src/test/scala/org/opencypher/v9_0/ast/ExpressionTest.scala
+++ b/ast/src/test/scala/org/opencypher/v9_0/ast/ExpressionTest.scala
@@ -92,7 +92,7 @@ class ExpressionTest extends CypherFunSuite with AstConstructionTestSupport {
       pattern = pat,
       predicate = None,
       projection = varFor("k")
-    )(pos)
+    )(pos, Set.empty)
 
     expr.withOuterScope(Set(varFor("n"), varFor("k"))).dependencies should equal(Set(varFor("n"), varFor("k")))
     expr.withOuterScope(Set.empty).dependencies should equal(Set.empty)

--- a/ast/src/test/scala/org/opencypher/v9_0/ast/semantics/PatternComprehensionTest.scala
+++ b/ast/src/test/scala/org/opencypher/v9_0/ast/semantics/PatternComprehensionTest.scala
@@ -30,7 +30,7 @@ class PatternComprehensionTest extends SemanticFunSuite {
   val stringLiteral = StringLiteral("APA")(pos)
 
   test("pattern comprehension on a property returns the expected type") {
-    val expression = PatternComprehension(None, pattern, None, property)(pos)
+    val expression = PatternComprehension(None, pattern, None, property)(pos, Set.empty)
 
     val result = SemanticExpressionCheck.simple(expression)(SemanticState.clean)
 
@@ -39,7 +39,7 @@ class PatternComprehensionTest extends SemanticFunSuite {
   }
 
   test("pattern comprehension with literal string projection has correct type") {
-    val expression = PatternComprehension(None, pattern, None, stringLiteral)(pos)
+    val expression = PatternComprehension(None, pattern, None, stringLiteral)(pos, Set.empty)
 
     val result = SemanticExpressionCheck.simple(expression)(SemanticState.clean)
 
@@ -48,7 +48,7 @@ class PatternComprehensionTest extends SemanticFunSuite {
   }
 
   test("inner projection using missing identifier reports error") {
-    val expression = PatternComprehension(None, pattern, None, failingProperty)(pos)
+    val expression = PatternComprehension(None, pattern, None, failingProperty)(pos, Set.empty)
 
     val result = SemanticExpressionCheck.simple(expression)(SemanticState.clean)
 
@@ -56,7 +56,7 @@ class PatternComprehensionTest extends SemanticFunSuite {
   }
 
   test("inner filter using missing identifier reports error") {
-    val expression = PatternComprehension(None, pattern, Some(failingProperty), stringLiteral)(pos)
+    val expression = PatternComprehension(None, pattern, Some(failingProperty), stringLiteral)(pos, Set.empty)
 
     val result = SemanticExpressionCheck.simple(expression)(SemanticState.clean)
 
@@ -64,7 +64,7 @@ class PatternComprehensionTest extends SemanticFunSuite {
   }
 
   test("pattern can't reuse identifier with different type") {
-    val expression = PatternComprehension(None, pattern, None, stringLiteral)(pos)
+    val expression = PatternComprehension(None, pattern, None, stringLiteral)(pos, Set.empty)
 
     val semanticState = SemanticState.clean.declareVariable(variable("n"), CTBoolean).right.get
     val result = SemanticExpressionCheck.simple(expression)(semanticState)

--- a/expressions/src/main/scala/org/opencypher/v9_0/expressions/IterableExpressions.scala
+++ b/expressions/src/main/scala/org/opencypher/v9_0/expressions/IterableExpressions.scala
@@ -74,20 +74,28 @@ object ListComprehension {
 }
 
 case class PatternComprehension(namedPath: Option[LogicalVariable], pattern: RelationshipsPattern,
-                                predicate: Option[Expression], projection: Expression,
-                                outerScope: Set[LogicalVariable] = Set.empty)
-                               (val position: InputPosition)
+                                predicate: Option[Expression], projection: Expression)
+                               (val position: InputPosition, val outerScope: Set[LogicalVariable])
   extends ScopeExpression {
 
   self =>
 
-  def withOuterScope(outerScope: Set[LogicalVariable]) =
-    copy(outerScope = outerScope)(position)
+  def withOuterScope(outerScope: Set[LogicalVariable]): PatternComprehension =
+    copy()(position, outerScope)
 
   override val introducedVariables: Set[LogicalVariable] = {
     val introducedInternally = namedPath.toSet ++ pattern.element.allVariables
     val introducedExternally = introducedInternally -- outerScope
     introducedExternally
+  }
+
+  override def dup(children: Seq[AnyRef]): this.type = {
+    PatternComprehension(
+      children(0).asInstanceOf[Option[LogicalVariable]],
+      children(1).asInstanceOf[RelationshipsPattern],
+      children(2).asInstanceOf[Option[Expression]],
+      children(3).asInstanceOf[Expression]
+    )(position, outerScope).asInstanceOf[this.type]
   }
 }
 

--- a/expressions/src/main/scala/org/opencypher/v9_0/expressions/MapProjection.scala
+++ b/expressions/src/main/scala/org/opencypher/v9_0/expressions/MapProjection.scala
@@ -20,13 +20,19 @@ import org.opencypher.v9_0.util.InputPosition
 case class MapProjection(
                           name: Variable, // Since this is always rewritten to DesugaredMapProjection this
                                           // (and in the elements below) may not need to be LogicalVariable
-                          items: Seq[MapProjectionElement],
-                          definitionPos: Option[InputPosition] = None)
-                        (val position: InputPosition)
+                          items: Seq[MapProjectionElement])
+                        (val position: InputPosition, val definitionPos: Option[InputPosition])
   extends Expression {
 
   def withDefinitionPos(pos:InputPosition): MapProjection =
-    copy(definitionPos = Some(pos))(position)
+    copy()(position, Some(pos))
+
+  override def dup(children: Seq[AnyRef]): this.type = {
+    MapProjection(
+      children(0).asInstanceOf[Variable],
+      children(1).asInstanceOf[Seq[MapProjectionElement]]
+    )(position, definitionPos).asInstanceOf[this.type]
+  }
 }
 
 case class DesugaredMapProjection(

--- a/frontend/src/main/scala/org/opencypher/v9_0/frontend/phases/CompilationPhases.scala
+++ b/frontend/src/main/scala/org/opencypher/v9_0/frontend/phases/CompilationPhases.scala
@@ -36,5 +36,6 @@ object CompilationPhases {
       transitiveClosure andThen
       rewriteEqualityToInPredicate andThen
       CNFNormalizer andThen
-      LateAstRewriting
+      LateAstRewriting andThen
+        SemanticAnalysis(warn = false)
 }

--- a/frontend/src/main/scala/org/opencypher/v9_0/frontend/phases/SemanticAnalysis.scala
+++ b/frontend/src/main/scala/org/opencypher/v9_0/frontend/phases/SemanticAnalysis.scala
@@ -16,8 +16,7 @@
 package org.opencypher.v9_0.frontend.phases
 
 import org.opencypher.v9_0.ast.UnaliasedReturnItem
-import org.opencypher.v9_0.ast.semantics.{SemanticChecker, SemanticFeature, SemanticState}
-import org.opencypher.v9_0.ast.semantics.{SemanticCheckResult, SemanticChecker, SemanticFeature, SemanticState}
+import org.opencypher.v9_0.ast.semantics.{SemanticCheckResult, SemanticChecker, SemanticFeature, SemanticState, SemanticTable}
 import org.opencypher.v9_0.frontend.phases.CompilationPhaseTracer.CompilationPhase.SEMANTIC_CHECK
 import org.opencypher.v9_0.rewriting.conditions.containsNoNodesOfType
 
@@ -37,7 +36,8 @@ case class SemanticAnalysis(warn: Boolean, features: SemanticFeature*)
 
     context.errorHandler(errors)
 
-    from.withSemanticState(state)
+    val table = SemanticTable(types = state.typeTable, recordedScopes = state.recordedScopes)
+    from.withSemanticState(state).withSemanticTable(table)
   }
 
   override def phase: CompilationPhaseTracer.CompilationPhase = SEMANTIC_CHECK

--- a/parser/src/main/scala/org/opencypher/v9_0/parser/Expressions.scala
+++ b/parser/src/main/scala/org/opencypher/v9_0/parser/Expressions.scala
@@ -202,8 +202,9 @@ trait Expressions extends Parser
     group("[" ~~ FilterExpression ~ optional(WS ~ "|" ~~ Expression) ~~ "]") ~~>> (ast.ListComprehension(_, _, _, _))
   }
 
-  def PatternComprehension: Rule1[org.opencypher.v9_0.expressions.PatternComprehension] = rule("[") {
-    group("[" ~~ optional(Variable ~~ operator("=")) ~~ RelationshipsPattern ~ optional(WS ~ keyword("WHERE") ~~ Expression) ~~ "|" ~~ Expression ~~ "]") ~~>> (ast.PatternComprehension(_, _, _, _))
+  def PatternComprehension: Rule1[ast.PatternComprehension] = rule("[") {
+    group("[" ~~ optional(Variable ~~ operator("=")) ~~ RelationshipsPattern ~ optional(WS ~ keyword("WHERE") ~~ Expression) ~~ "|" ~~ Expression ~~ "]") ~~>> (
+      (a, b, c, d) => pos => ast.PatternComprehension(a, b, c, d)(pos, Set.empty))
   }
 
   def CaseExpression: Rule1[org.opencypher.v9_0.expressions.CaseExpression] = rule("CASE") {

--- a/parser/src/main/scala/org/opencypher/v9_0/parser/Literals.scala
+++ b/parser/src/main/scala/org/opencypher/v9_0/parser/Literals.scala
@@ -101,10 +101,10 @@ trait Literals extends Parser
   def AllPropertiesSelector: Rule1[org.opencypher.v9_0.expressions.MapProjectionElement] = rule("all properties selector")(
     ch('.') ~~ ch('*') ~ push(ast.AllPropertiesSelector()(_)))
 
-  def MapProjection: Rule1[org.opencypher.v9_0.expressions.MapProjection] = rule {
+  def MapProjection: Rule1[ast.MapProjection] = rule {
     group(
       Variable ~~ ch('{') ~~ zeroOrMore(LiteralEntry | PropertySelector | VariableSelector | AllPropertiesSelector, CommaSep) ~~ ch('}')
-    ) ~~>> (ast.MapProjection(_, _))
+    ) ~~>> ((a, b) => pos => ast.MapProjection(a, b)(pos, None))
   }
 
   def Parameter: Rule1[org.opencypher.v9_0.expressions.Parameter] = rule("a parameter") {

--- a/parser/src/test/scala/org/opencypher/v9_0/parser/MapProjectionTest.scala
+++ b/parser/src/test/scala/org/opencypher/v9_0/parser/MapProjectionTest.scala
@@ -27,23 +27,23 @@ class MapProjectionTest extends ParserTest[Any, Any] with Expressions {
   test("testIdentifierCanContainASCII") {
     implicit val parserToTest = MapProjection
 
-    parsing("abc{}") shouldGive exp.MapProjection(exp.Variable("abc")(t), Seq.empty)(t)
+    parsing("abc{}") shouldGive exp.MapProjection(exp.Variable("abc")(t), Seq.empty)(t, None)
 
     parsing("abc{.id}") shouldGive
       exp.MapProjection(exp.Variable("abc")(t),
-        Seq(exp.PropertySelector(exp.Variable("id")(t))(t)))(t)
+        Seq(exp.PropertySelector(exp.Variable("id")(t))(t)))(t, None)
 
     parsing("abc{id}") shouldGive
       exp.MapProjection(exp.Variable("abc")(t),
-        Seq(exp.VariableSelector(exp.Variable("id")(t))(t)))(t)
+        Seq(exp.VariableSelector(exp.Variable("id")(t))(t)))(t, None)
 
     parsing("abc { id : 42 }") shouldGive
       exp.MapProjection(exp.Variable("abc")(t),
-        Seq(exp.LiteralEntry(exp.PropertyKeyName("id")(t), SignedDecimalIntegerLiteral("42")(t))(t)))(t)
+        Seq(exp.LiteralEntry(exp.PropertyKeyName("id")(t), SignedDecimalIntegerLiteral("42")(t))(t)))(t, None)
 
     parsing("abc { `a p a` : 42 }") shouldGive
       exp.MapProjection(exp.Variable("abc")(t),
-        Seq(exp.LiteralEntry(exp.PropertyKeyName("a p a")(t), SignedDecimalIntegerLiteral("42")(t))(t)))(t)
+        Seq(exp.LiteralEntry(exp.PropertyKeyName("a p a")(t), SignedDecimalIntegerLiteral("42")(t))(t)))(t, None)
 
     parsing("abc { id : 42, .foo, bar }") shouldGive
       exp.MapProjection(exp.Variable("abc")(t),
@@ -52,7 +52,7 @@ class MapProjectionTest extends ParserTest[Any, Any] with Expressions {
           exp.PropertySelector(exp.Variable("foo")(t))(t),
           exp.VariableSelector(exp.Variable("bar")(t))(t)
         )
-      )(t)
+      )(t, None)
   }
 
   def convert(result: Any): Any = result

--- a/rewriting/src/main/scala/org/opencypher/v9_0/rewriting/rewriters/PatternExpressionPatternElementNamer.scala
+++ b/rewriting/src/main/scala/org/opencypher/v9_0/rewriting/rewriters/PatternExpressionPatternElementNamer.scala
@@ -31,7 +31,7 @@ object PatternExpressionPatternElementNamer {
   def apply(expr: PatternComprehension): (PatternComprehension, Map[PatternElement, Variable]) = {
     val unnamedMap = nameUnnamedPatternElements(expr.pattern)
     val namedPattern = expr.pattern.endoRewrite(namePatternElementsFromMap(unnamedMap))
-    val namedExpr = expr.copy(pattern = namedPattern)(expr.position)
+    val namedExpr = expr.copy(pattern = namedPattern)(expr.position, expr.outerScope)
     (namedExpr, unnamedMap)
   }
 

--- a/rewriting/src/main/scala/org/opencypher/v9_0/rewriting/rewriters/desugarMapProjection.scala
+++ b/rewriting/src/main/scala/org/opencypher/v9_0/rewriting/rewriters/desugarMapProjection.scala
@@ -33,11 +33,11 @@ case class desugarMapProjection(state: SemanticState) extends Rewriter {
   def apply(that: AnyRef): AnyRef = topDown(instance).apply(that)
 
   private val instance: Rewriter = Rewriter.lift {
-    case e@MapProjection(id, items, definitionPos) =>
+    case e@MapProjection(id, items) =>
 
       def propertySelect(propertyPosition: InputPosition, name: String): LiteralEntry = {
         val key = PropertyKeyName(name)(propertyPosition)
-        val idPos = definitionPos.getOrElse(throw new InternalException("MapProjection definition pos is not known"))
+        val idPos = e.definitionPos.getOrElse(throw new InternalException("MapProjection definition pos is not known"))
         val newIdentifier = Variable(id.name)(idPos)
         val value = Property(newIdentifier, key)(propertyPosition)
         LiteralEntry(key, value)(propertyPosition)

--- a/rewriting/src/main/scala/org/opencypher/v9_0/rewriting/rewriters/inlineNamedPathsInPatternComprehensions.scala
+++ b/rewriting/src/main/scala/org/opencypher/v9_0/rewriting/rewriters/inlineNamedPathsInPatternComprehensions.scala
@@ -22,13 +22,13 @@ import org.opencypher.v9_0.expressions.{PathExpression, PatternElement}
 case object inlineNamedPathsInPatternComprehensions extends Rewriter {
 
   private val instance = bottomUp(Rewriter.lift {
-    case expr @ PatternComprehension(Some(path), pattern, predicate, projection, _) =>
+    case expr @ PatternComprehension(Some(path), pattern, predicate, projection) =>
       val patternElement = pattern.element
       expr.copy(
         namedPath = None,
         predicate = predicate.map(_.inline(path, patternElement)),
         projection = projection.inline(path, patternElement)
-      )(expr.position)
+      )(expr.position, expr.outerScope)
   })
 
   private implicit final class InliningExpression(val expr: Expression) extends AnyVal {

--- a/rewriting/src/test/scala/org/opencypher/v9_0/rewriting/conditions/noUnnamedPatternElementsInPatternComprehensionTest.scala
+++ b/rewriting/src/test/scala/org/opencypher/v9_0/rewriting/conditions/noUnnamedPatternElementsInPatternComprehensionTest.scala
@@ -28,7 +28,7 @@ class noUnnamedPatternElementsInPatternComprehensionTest extends CypherFunSuite 
     val input: ASTNode = PatternComprehension(None, RelationshipsPattern(
       RelationshipChain(NodePattern(None, Seq.empty, None) _,
                         RelationshipPattern(None, Seq.empty, None, None, SemanticDirection.OUTGOING) _,
-                        NodePattern(None, Seq.empty, None) _) _) _, None, StringLiteral("foo") _) _
+                        NodePattern(None, Seq.empty, None) _) _) _, None, StringLiteral("foo") _)(pos, Set.empty)
 
     condition(input) should equal(Seq(s"Expression $input contains pattern elements which are not named"))
   }
@@ -39,7 +39,7 @@ class noUnnamedPatternElementsInPatternComprehensionTest extends CypherFunSuite 
                                                                                                   RelationshipPattern(Some(varFor("r")), Seq.empty, None, None, SemanticDirection.OUTGOING) _,
                                                                                                   NodePattern(Some(varFor("b")), Seq.empty, None) _) _) _,
                                                            None,
-                                                           StringLiteral("foo")_)_
+                                                           StringLiteral("foo")_)(pos, Set.empty)
 
     condition(input) shouldBe empty
   }

--- a/rewriting/src/test/scala/org/opencypher/v9_0/rewriting/inlineNamedPathsInPatternComprehensionsTest.scala
+++ b/rewriting/src/test/scala/org/opencypher/v9_0/rewriting/inlineNamedPathsInPatternComprehensionsTest.scala
@@ -26,16 +26,16 @@ class inlineNamedPathsInPatternComprehensionsTest extends CypherFunSuite with As
 
   // [ ()-->() | 'foo' ]
   test("does not touch comprehensions without named path") {
-    val input: ASTNode = PatternComprehension(None, RelationshipsPattern(RelationshipChain(NodePattern(None, Seq.empty, None) _, RelationshipPattern(None, Seq.empty, None, None, SemanticDirection.OUTGOING) _, NodePattern(None, Seq.empty, None) _) _)_, None, StringLiteral("foo")_)_
+    val input: ASTNode = PatternComprehension(None, RelationshipsPattern(RelationshipChain(NodePattern(None, Seq.empty, None) _, RelationshipPattern(None, Seq.empty, None, None, SemanticDirection.OUTGOING) _, NodePattern(None, Seq.empty, None) _) _)_, None, StringLiteral("foo")_)(pos, Set.empty)
 
     inlineNamedPathsInPatternComprehensions(input) should equal(input)
   }
 
   // [ p = (a)-[r]->(b) | 'foo' ]
   test("removes named path if not used") {
-    val input: PatternComprehension = PatternComprehension(Some(varFor("p")), RelationshipsPattern(RelationshipChain(NodePattern(Some(varFor("a")), Seq.empty, None) _, RelationshipPattern(Some(varFor("r")), Seq.empty, None, None, SemanticDirection.OUTGOING) _, NodePattern(Some(varFor("b")), Seq.empty, None) _) _)_, None, StringLiteral("foo")_)_
+    val input: PatternComprehension = PatternComprehension(Some(varFor("p")), RelationshipsPattern(RelationshipChain(NodePattern(Some(varFor("a")), Seq.empty, None) _, RelationshipPattern(Some(varFor("r")), Seq.empty, None, None, SemanticDirection.OUTGOING) _, NodePattern(Some(varFor("b")), Seq.empty, None) _) _)_, None, StringLiteral("foo")_)(pos, Set.empty)
 
-    inlineNamedPathsInPatternComprehensions(input) should equal(input.copy(namedPath = None)(pos))
+    inlineNamedPathsInPatternComprehensions(input) should equal(input.copy(namedPath = None)(pos, input.outerScope))
   }
 
   // [ p = (a)-[r]->(b) | p ]
@@ -44,8 +44,8 @@ class inlineNamedPathsInPatternComprehensionsTest extends CypherFunSuite with As
                                                        RelationshipPattern(Some(varFor("r")), Seq.empty, None,
                                                                            None, SemanticDirection.OUTGOING) _,
                                                        NodePattern(Some(varFor("b")), Seq.empty, None) _) _
-    val input: PatternComprehension = PatternComprehension(Some(varFor("p")), RelationshipsPattern(element)_, None, Variable("p")_)_
-    val output = input.copy(namedPath = None, projection = PathExpression(projectNamedPaths.patternPartPathExpression(element))_)(pos)
+    val input: PatternComprehension = PatternComprehension(Some(varFor("p")), RelationshipsPattern(element)_, None, Variable("p")_)(pos, Set.empty)
+    val output = input.copy(namedPath = None, projection = PathExpression(projectNamedPaths.patternPartPathExpression(element))(pos))(pos, input.outerScope)
 
     inlineNamedPathsInPatternComprehensions(input) should equal(output)
   }
@@ -56,11 +56,11 @@ class inlineNamedPathsInPatternComprehensionsTest extends CypherFunSuite with As
                                                        RelationshipPattern(Some(varFor("r")), Seq.empty, None,
                                                                            None, SemanticDirection.OUTGOING) _,
                                                        NodePattern(Some(varFor("b")), Seq.empty, None) _) _
-    val input: PatternComprehension = PatternComprehension(Some(varFor("p")), RelationshipsPattern(element)_, Some(varFor("p")), StringLiteral("foo")_)_
+    val input: PatternComprehension = PatternComprehension(Some(varFor("p")), RelationshipsPattern(element)_, Some(varFor("p")), StringLiteral("foo")_)(pos, Set.empty)
     val output = input.copy(
       namedPath = None,
       predicate = Some(PathExpression(projectNamedPaths.patternPartPathExpression(element))_)
-    )(pos)
+    )(pos, input.outerScope)
 
     inlineNamedPathsInPatternComprehensions(input) should equal(output)
   }
@@ -72,12 +72,12 @@ class inlineNamedPathsInPatternComprehensionsTest extends CypherFunSuite with As
                                                        RelationshipPattern(Some(varFor("r")), Seq.empty, None,
                                                                            None, SemanticDirection.OUTGOING) _,
                                                        NodePattern(Some(varFor("b")), Seq.empty, None) _) _
-    val input: PatternComprehension = PatternComprehension(Some(varFor("p")), RelationshipsPattern(element)_, Some(varFor("p")), Variable("p")_)_
+    val input: PatternComprehension = PatternComprehension(Some(varFor("p")), RelationshipsPattern(element)_, Some(varFor("p")), Variable("p")_)(pos, Set.empty)
     val output = input.copy(
       namedPath = None,
       predicate = Some(PathExpression(projectNamedPaths.patternPartPathExpression(element))_),
-      projection = PathExpression(projectNamedPaths.patternPartPathExpression(element))_
-    )(pos)
+      projection = PathExpression(projectNamedPaths.patternPartPathExpression(element))(pos)
+    )(pos, input.outerScope)
 
     inlineNamedPathsInPatternComprehensions(input) should equal(output)
   }

--- a/rewriting/src/test/scala/org/opencypher/v9_0/rewriting/namePatternComprehensionPatternElementsTest.scala
+++ b/rewriting/src/test/scala/org/opencypher/v9_0/rewriting/namePatternComprehensionPatternElementsTest.scala
@@ -28,12 +28,12 @@ class namePatternComprehensionPatternElementsTest extends CypherFunSuite with As
     val input: ASTNode = PatternComprehension(None, RelationshipsPattern(
       RelationshipChain(NodePattern(None, Seq.empty, None) _,
                         RelationshipPattern(None, Seq.empty, None, None, SemanticDirection.OUTGOING) _,
-                        NodePattern(None, Seq.empty, None) _) _) _, None, StringLiteral("foo") _) _
+                        NodePattern(None, Seq.empty, None) _) _) _, None, StringLiteral("foo") _)(pos, Set.empty)
 
     namePatternComprehensionPatternElements(input) match {
       case PatternComprehension(_, RelationshipsPattern(RelationshipChain(NodePattern(Some(_), _, _, _),
                                                                           RelationshipPattern(Some(_), _, _, _, _, _, _),
-                                                                          NodePattern(Some(_), _, _, _))), _, _, _) => ()
+                                                                          NodePattern(Some(_), _, _, _))), _, _) => ()
       case _ => fail("All things were not named")
     }
   }
@@ -44,7 +44,7 @@ class namePatternComprehensionPatternElementsTest extends CypherFunSuite with As
                                                                                                   RelationshipPattern(Some(varFor("r")), Seq.empty, None, None, SemanticDirection.OUTGOING) _,
                                                                                                   NodePattern(Some(varFor("b")), Seq.empty, None) _) _) _,
                                                            None,
-                                                           StringLiteral("foo")_)_
+                                                           StringLiteral("foo")_)(pos, Set.empty)
 
     namePatternComprehensionPatternElements(input) should equal(input)
   }


### PR DESCRIPTION
Fixes a problem where a `PatternComprehension` after the `recordScopes` rewriting would not longer exist in the `SemanticState` scopes datastructure. Also fixed a problem with missing expressions in the semantic table due to late ast rewriting (e.g. `namespacer`)

Note: this was already reviewed for fixing in Neo4j 3.4.