### PR TITLE
Refactor deprecations and deprecate most list-comprehension-like functions

### DIFF
--- a/frontend/src/main/scala/org/opencypher/v9_0/frontend/phases/CompilationPhases.scala
+++ b/frontend/src/main/scala/org/opencypher/v9_0/frontend/phases/CompilationPhases.scala
@@ -18,14 +18,17 @@ package org.opencypher.v9_0.frontend.phases
 import org.opencypher.v9_0.ast.Statement
 import org.opencypher.v9_0.ast.semantics.SemanticState
 import org.opencypher.v9_0.rewriting.rewriters.{IfNoParameter, LiteralExtraction}
-import org.opencypher.v9_0.rewriting.RewriterStepSequencer
+import org.opencypher.v9_0.rewriting.{Deprecations, RewriterStepSequencer}
 
 object CompilationPhases {
 
-  def parsing(sequencer: String => RewriterStepSequencer, literalExtraction: LiteralExtraction = IfNoParameter): Transformer[BaseContext, BaseState, BaseState] =
+  def parsing(sequencer: String => RewriterStepSequencer,
+              literalExtraction: LiteralExtraction = IfNoParameter,
+              deprecations: Deprecations = Deprecations.V1
+             ): Transformer[BaseContext, BaseState, BaseState] =
     Parsing.adds(BaseContains[Statement]) andThen
-      SyntaxDeprecationWarnings andThen
-      PreparatoryRewriting andThen
+      SyntaxDeprecationWarnings(deprecations) andThen
+      PreparatoryRewriting(deprecations) andThen
       SemanticAnalysis(warn = true).adds(BaseContains[SemanticState]) andThen
       AstRewriting(sequencer, literalExtraction)
 

--- a/frontend/src/main/scala/org/opencypher/v9_0/frontend/phases/PreparatoryRewriting.scala
+++ b/frontend/src/main/scala/org/opencypher/v9_0/frontend/phases/PreparatoryRewriting.scala
@@ -18,15 +18,16 @@ package org.opencypher.v9_0.frontend.phases
 import org.opencypher.v9_0.rewriting.rewriters._
 import org.opencypher.v9_0.util.inSequence
 import org.opencypher.v9_0.frontend.phases.CompilationPhaseTracer.CompilationPhase.AST_REWRITE
+import org.opencypher.v9_0.rewriting.Deprecations
 
-case object PreparatoryRewriting extends Phase[BaseContext, BaseState, BaseState] {
+case class PreparatoryRewriting(deprecations: Deprecations) extends Phase[BaseContext, BaseState, BaseState] {
 
   override def process(from: BaseState, context: BaseContext): BaseState = {
 
     val rewrittenStatement = from.statement().endoRewrite(inSequence(
       normalizeWithAndReturnClauses(context.exceptionCreator),
       expandCallWhere,
-      replaceAliasedFunctionInvocations,
+      replaceAliasedFunctionInvocations(deprecations),
       mergeInPredicates))
 
     from.withStatement(rewrittenStatement)

--- a/frontend/src/test/scala/org/opencypher/v9_0/frontend/MultipleGraphClauseSemanticCheckingTest.scala
+++ b/frontend/src/test/scala/org/opencypher/v9_0/frontend/MultipleGraphClauseSemanticCheckingTest.scala
@@ -20,6 +20,7 @@ import org.opencypher.v9_0.ast.{AstConstructionTestSupport, Query, Statement}
 import org.opencypher.v9_0.frontend.helpers.{TestContext, TestState}
 import org.opencypher.v9_0.frontend.phases._
 import org.opencypher.v9_0.parser.ParserTest
+import org.opencypher.v9_0.rewriting.Deprecations
 import org.opencypher.v9_0.{ast, parser}
 import org.parboiled.scala.Rule1
 
@@ -516,7 +517,7 @@ class MultipleGraphClauseSemanticCheckingTest
   }
 
   override def convert(astNode: ast.Statement): SemanticCheckResult = {
-    val rewritten = PreparatoryRewriting.transform(TestState(Some(astNode)), TestContext()).statement()
+    val rewritten = PreparatoryRewriting(Deprecations.V1).transform(TestState(Some(astNode)), TestContext()).statement()
     val initialState = SemanticState.clean.withFeatures(SemanticFeature.MultipleGraphs, SemanticFeature.WithInitialQuerySignature)
     rewritten.semanticCheck(initialState)
   }

--- a/frontend/src/test/scala/org/opencypher/v9_0/frontend/phases/SyntaxDeprecationWarningsTest.scala
+++ b/frontend/src/test/scala/org/opencypher/v9_0/frontend/phases/SyntaxDeprecationWarningsTest.scala
@@ -36,6 +36,7 @@ class SyntaxDeprecationWarningsTest extends CypherFunSuite with AstConstructionT
 
   test("should warn about V2 deprecations") {
     check(V2, "RETURN extract(a IN [{x: 1},{x: 2}] | a.x)") should be(Set(DeprecatedFunctionNotification(returnPos, "extract(...)", "[...]")))
+    check(V2, "RETURN filter(a IN [{x: 1},{x: 2}] WHERE a.x = 1)") should be(Set(DeprecatedFunctionNotification(returnPos, "filter(...)", "[...]")))
   }
 
   private def check(deprecations: Deprecations, query: String) = {

--- a/frontend/src/test/scala/org/opencypher/v9_0/frontend/phases/SyntaxDeprecationWarningsTest.scala
+++ b/frontend/src/test/scala/org/opencypher/v9_0/frontend/phases/SyntaxDeprecationWarningsTest.scala
@@ -18,6 +18,7 @@ package org.opencypher.v9_0.frontend.phases
 import org.opencypher.v9_0.ast.{AstConstructionTestSupport, Statement}
 import org.opencypher.v9_0.frontend.helpers.{TestContext, TestState}
 import org.opencypher.v9_0.parser.ParserFixture.parser
+import org.opencypher.v9_0.rewriting.Deprecations
 import org.opencypher.v9_0.util.test_helpers.CypherFunSuite
 import org.opencypher.v9_0.util.{DeprecatedFunctionNotification, InputPosition}
 
@@ -32,7 +33,7 @@ class SyntaxDeprecationWarningsTest extends CypherFunSuite with  AstConstruction
 
   private def check(query: String) = {
     val logger = new RecordingNotificationLogger()
-    SyntaxDeprecationWarnings.visit(TestState(Some(parse(query))), TestContext(logger))
+    SyntaxDeprecationWarnings(Deprecations.V1).visit(TestState(Some(parse(query))), TestContext(logger))
     logger.notifications
   }
 

--- a/rewriting/src/main/scala/org/opencypher/v9_0/rewriting/Deprecation.scala
+++ b/rewriting/src/main/scala/org/opencypher/v9_0/rewriting/Deprecation.scala
@@ -69,6 +69,32 @@ object Deprecations {
     }
   }
 
+  case object V2 extends Deprecations {
+    private val functionRenames: Map[String, String] =
+      TreeMap(
+        "toInt" -> "toInteger",
+        "upper" -> "toUpper",
+        "lower" -> "toLower",
+        "rels" -> "relationships"
+      )(CaseInsensitiveOrdered)
+
+    override val find: PartialFunction[Any, Deprecation] = {
+
+      val additionalDeprecations: PartialFunction[Any, Deprecation] = {
+
+        // extract => list comprehension
+        case e@ExtractExpression(scope, expression) =>
+          Deprecation(
+            () => ListComprehension(scope, expression)(e.position),
+            () => Some(DeprecatedFunctionNotification(e.position, "extract(...)", "[...]"))
+          )
+
+      }
+
+      additionalDeprecations.orElse(V1.find)
+    }
+  }
+
   object CaseInsensitiveOrdered extends Ordering[String] {
     def compare(x: String, y: String): Int =
       x.compareToIgnoreCase(y)

--- a/rewriting/src/main/scala/org/opencypher/v9_0/rewriting/Deprecation.scala
+++ b/rewriting/src/main/scala/org/opencypher/v9_0/rewriting/Deprecation.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2002-2018 Neo4j Sweden AB (http://neo4j.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opencypher.v9_0.rewriting
+
+import org.opencypher.v9_0.expressions._
+import org.opencypher.v9_0.util._
+
+import scala.collection.immutable.TreeMap
+
+object Deprecations {
+
+  def propertyOf(propertyKey:String): Expression => Expression =
+    e => Property(e, PropertyKeyName(propertyKey)(e.position))(e.position)
+
+  def renameFunctionTo(newName: String): FunctionInvocation => FunctionInvocation =
+    f => f.copy(functionName = FunctionName(newName)(f.functionName.position))(f.position)
+
+  case object V1 extends Deprecations {
+    private val functionRenames: Map[String, String] =
+      TreeMap(
+        "toInt" -> "toInteger",
+        "upper" -> "toUpper",
+        "lower" -> "toLower",
+        "rels" -> "relationships"
+      )(CaseInsensitiveOrdered)
+
+    override val find: PartialFunction[Any, Deprecation] = {
+
+      // straight renames
+      case f@FunctionInvocation(namespace, FunctionName(name), distinct, args) if functionRenames.contains(name) =>
+        Deprecation(
+          () => renameFunctionTo(functionRenames(name))(f),
+          () => Some(DeprecatedFunctionNotification(f.position, name, functionRenames(name)))
+        )
+
+      // timestamp
+      case f@FunctionInvocation(namespace, FunctionName("timestamp"), distinct, args) =>
+        Deprecation(
+          () => renameFunctionTo("datetime").andThen(propertyOf("epochMillis"))(f),
+          () => None
+        )
+
+      // var-length binding
+      case p@RelationshipPattern(Some(variable), _, Some(_), _, _, _, _) =>
+        Deprecation(
+          () => p,
+          () => Some(DeprecatedVarLengthBindingNotification(p.position, variable.name))
+        )
+
+      // legacy type separator
+      case p@RelationshipPattern(variable, _, length, properties, _, true, _) if variable.isDefined || length.isDefined || properties.isDefined =>
+        Deprecation(
+          () => p,
+          () => Some(DeprecatedRelTypeSeparatorNotification(p.position))
+        )
+    }
+  }
+
+  object CaseInsensitiveOrdered extends Ordering[String] {
+    def compare(x: String, y: String): Int =
+      x.compareToIgnoreCase(y)
+  }
+}
+
+/**
+  * One deprecation.
+  *
+  * This class holds both the ability to replace a part of the AST with the preferred non-deprecated variant, and
+  * the ability to generate an optional notification to the user that they are using a deprecated feature.
+  *
+  * @param generateReplacement function which rewrites the matched construct
+  * @param generateNotification function which generates an appropriate deprecation notification
+  */
+case class Deprecation(generateReplacement: () => ASTNode, generateNotification: () => Option[InternalNotification])
+
+trait Deprecations extends {
+  def find: PartialFunction[Any, Deprecation]
+}

--- a/rewriting/src/main/scala/org/opencypher/v9_0/rewriting/Deprecation.scala
+++ b/rewriting/src/main/scala/org/opencypher/v9_0/rewriting/Deprecation.scala
@@ -89,6 +89,13 @@ object Deprecations {
             () => Some(DeprecatedFunctionNotification(e.position, "extract(...)", "[...]"))
           )
 
+        // filter => list comprehension
+        case e@FilterExpression(scope, expression) =>
+          Deprecation(
+            () => ListComprehension(ExtractScope(scope.variable, scope.innerPredicate, None)(scope.position), expression)(e.position),
+            () => Some(DeprecatedFunctionNotification(e.position, "filter(...)", "[...]"))
+          )
+
       }
 
       additionalDeprecations.orElse(V1.find)

--- a/rewriting/src/main/scala/org/opencypher/v9_0/rewriting/rewriters/replaceAliasedFunctionInvocations.scala
+++ b/rewriting/src/main/scala/org/opencypher/v9_0/rewriting/rewriters/replaceAliasedFunctionInvocations.scala
@@ -15,46 +15,11 @@
  */
 package org.opencypher.v9_0.rewriting.rewriters
 
-import org.opencypher.v9_0.expressions._
+import org.opencypher.v9_0.rewriting.Deprecations
 import org.opencypher.v9_0.util.{Rewriter, bottomUp}
 
-import scala.collection.immutable.TreeMap
-
-case object replaceAliasedFunctionInvocations extends Rewriter {
+case class replaceAliasedFunctionInvocations(deprecations: Deprecations) extends Rewriter {
 
   override def apply(that: AnyRef): AnyRef = instance(that)
-
-  /*
-   * These are historical names for functions. They are all subject to removal in an upcoming major release.
-   */
-  val deprecatedFunctionReplacements: Map[String, String] = TreeMap("toInt" -> "toInteger",
-                                                                    "upper" -> "toUpper",
-                                                                    "lower" -> "toLower",
-                                                                    "rels" -> "relationships")(CaseInsensitiveOrdered)
-
-  private def propertyOf(propertyKey:String): Expression => Expression =
-    (incoming:Expression) => Property(incoming, PropertyKeyName(propertyKey)(incoming.position))(incoming.position)
-
-  private val renameFunction: FunctionInvocation => Expression =
-    (incoming:FunctionInvocation) => renameFunctionTo(deprecatedFunctionReplacements(incoming.name))(incoming)
-
-  private def renameFunctionTo(newName: String) = (incoming: FunctionInvocation) =>
-    incoming.copy(functionName = FunctionName(newName)(incoming.functionName.position))(incoming.position)
-
-  private val aliases: Map[String, FunctionInvocation => Expression] = TreeMap("toInt" -> renameFunction,
-                                                                               "upper" -> renameFunction,
-                                                                               "lower" -> renameFunction,
-                                                                               "rels" -> renameFunction,
-                                                                               "timestamp" ->
-                                                                                 renameFunctionTo("datetime")
-                                                                                   .andThen(propertyOf("epochMillis")))(CaseInsensitiveOrdered)
-
-  val instance: Rewriter = bottomUp(Rewriter.lift {
-    case func@FunctionInvocation(_, FunctionName(name), _, _) if aliases.contains(name) => aliases(name)(func)
-  })
-}
-
-object CaseInsensitiveOrdered extends Ordering[String] {
-  def compare(x: String, y: String): Int =
-    x.compareToIgnoreCase(y)
+  val instance: Rewriter = bottomUp(Rewriter.lift(deprecations.find.andThen(d => d.generateReplacement())))
 }

--- a/rewriting/src/test/scala/org/opencypher/v9_0/rewriting/ReplaceAliasedFunctionInvocationsTest.scala
+++ b/rewriting/src/test/scala/org/opencypher/v9_0/rewriting/ReplaceAliasedFunctionInvocationsTest.scala
@@ -18,6 +18,7 @@ package org.opencypher.v9_0.rewriting
 import org.opencypher.v9_0.ast.AstConstructionTestSupport
 import org.opencypher.v9_0.expressions._
 import org.opencypher.v9_0.rewriting.rewriters.replaceAliasedFunctionInvocations
+import org.opencypher.v9_0.util.InputPosition
 import org.opencypher.v9_0.util.test_helpers.CypherFunSuite
 
 class ReplaceAliasedFunctionInvocationsTest extends CypherFunSuite with AstConstructionTestSupport {
@@ -50,6 +51,16 @@ class ReplaceAliasedFunctionInvocationsTest extends CypherFunSuite with AstConst
     val scope = ExtractScope(varFor("a"), None, None)(pos)
     val before = ExtractExpression(scope, literalFloat(3.0))(pos)
     val expected = ListComprehension(scope, literalFloat(3.0))(pos)
+
+    replaceAliasedFunctionInvocations(Deprecations.V1)(before) should equal(before)
+    replaceAliasedFunctionInvocations(Deprecations.V2)(before) should equal(expected)
+  }
+
+  test("should rewrite filter() in V2") {
+    val scopePosition = InputPosition(30, 1, 31)
+    val scope = FilterScope(varFor("a"), Some(TRUE))(scopePosition)
+    val before = FilterExpression(scope, literalFloat(3.0))(pos)
+    val expected = ListComprehension(ExtractScope(varFor("a"), Some(TRUE), None)(scopePosition), literalFloat(3.0))(pos)
 
     replaceAliasedFunctionInvocations(Deprecations.V1)(before) should equal(before)
     replaceAliasedFunctionInvocations(Deprecations.V2)(before) should equal(expected)

--- a/rewriting/src/test/scala/org/opencypher/v9_0/rewriting/ReplaceAliasedFunctionInvocationsTest.scala
+++ b/rewriting/src/test/scala/org/opencypher/v9_0/rewriting/ReplaceAliasedFunctionInvocationsTest.scala
@@ -46,4 +46,13 @@ class ReplaceAliasedFunctionInvocationsTest extends CypherFunSuite with AstConst
     rewriter(before) should equal(after)
   }
 
+  test("should rewrite extract() in V2") {
+    val scope = ExtractScope(varFor("a"), None, None)(pos)
+    val before = ExtractExpression(scope, literalFloat(3.0))(pos)
+    val expected = ListComprehension(scope, literalFloat(3.0))(pos)
+
+    replaceAliasedFunctionInvocations(Deprecations.V1)(before) should equal(before)
+    replaceAliasedFunctionInvocations(Deprecations.V2)(before) should equal(expected)
+  }
+
 }

--- a/rewriting/src/test/scala/org/opencypher/v9_0/rewriting/ReplaceAliasedFunctionInvocationsTest.scala
+++ b/rewriting/src/test/scala/org/opencypher/v9_0/rewriting/ReplaceAliasedFunctionInvocationsTest.scala
@@ -22,7 +22,7 @@ import org.opencypher.v9_0.util.test_helpers.CypherFunSuite
 
 class ReplaceAliasedFunctionInvocationsTest extends CypherFunSuite with AstConstructionTestSupport {
 
-  val rewriter = replaceAliasedFunctionInvocations
+  private val rewriter = replaceAliasedFunctionInvocations(Deprecations.V1)
 
   test("should rewrite toInt()") {
     val before = FunctionInvocation(FunctionName("toInt")(pos), literalInt(1))(pos)
@@ -38,7 +38,6 @@ class ReplaceAliasedFunctionInvocationsTest extends CypherFunSuite with AstConst
 
   test("should rewrite timestamp()") {
     val before = FunctionInvocation(FunctionName("timestamp")(pos), distinct = false, IndexedSeq.empty)(pos)
-
 
     val after =
       Property(


### PR DESCRIPTION
Refactors the deprecation and function replacement code to keep all deprecations in one place, and make them easier to extend. The current deprecation behavior is now encapsulated in `Deprecations.V1`. This PR then adds an extended deprecation set `V2`, in which `extract()`, and `filter()` are deprecated in addition to the `V1` set. These functions can all be replaced easily by a list-comprehension. See https://github.com/opencypher/openCypher/issues/228. 

EDIT: This PR used to deprecate `all()`, `any()`, `none()` and `single()`, but we have changed our minds and no longer want to deprecate these, as rewriting these as list comprehensions has subtly different semantics which also come with performance implications.

