### PR TITLE
Fix bug in Namespacer

### DIFF
--- a/frontend/src/test/scala/org/opencypher/v9_0/frontend/SemanticAnalysisTest.scala
+++ b/frontend/src/test/scala/org/opencypher/v9_0/frontend/SemanticAnalysisTest.scala
@@ -62,8 +62,6 @@ class SemanticAnalysisTest extends CypherFunSuite with AstConstructionTestSuppor
 
     pipeline.transform(startState, ErrorCollectingContext)
 
-    println(ErrorCollectingContext.errors)
-
     ErrorCollectingContext.errors.map(_.msg) should equal(List("Multiple result columns with the same name are not supported"))
   }
 

--- a/frontend/src/test/scala/org/opencypher/v9_0/frontend/phases/NamespacerTest.scala
+++ b/frontend/src/test/scala/org/opencypher/v9_0/frontend/phases/NamespacerTest.scala
@@ -146,6 +146,11 @@ class NamespacerTest extends CypherFunSuite with AstConstructionTestSupport with
       "WITH 1 AS foo FOREACH (bar IN [1,2,3] | CREATE (c)) RETURN foo as bar ORDER BY bar",
       "WITH 1 AS foo FOREACH (`  bar@23` IN [1,2,3] | CREATE (c)) RETURN foo as bar ORDER BY bar",
       List(varFor("  bar@23"))
+    ),
+    TestCase(
+      "WITH 1 AS foo FOREACH (bar IN [1,2,3] | CREATE (c)) RETURN foo as bar ORDER BY bar + 2",
+      "WITH 1 AS foo FOREACH (`  bar@23` IN [1,2,3] | CREATE (c)) RETURN foo as bar ORDER BY bar + 2",
+      List(varFor("  bar@23"))
     )
   )
 


### PR DESCRIPTION
so that it does not rewrite protected variable names
in ORDER BY if they appear nested in another Expression.