### PR TITLE
Fix errors in semantic checking

### DIFF
--- a/expressions/src/main/scala/org/opencypher/v9_0/expressions/ArithmeticExpressions.scala
+++ b/expressions/src/main/scala/org/opencypher/v9_0/expressions/ArithmeticExpressions.scala
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 package org.opencypher.v9_0.expressions
-
 import org.opencypher.v9_0.util.InputPosition
 import org.opencypher.v9_0.util.symbols._
 
@@ -42,6 +41,7 @@ case class Subtract(lhs: Expression, rhs: Expression)(val position: InputPositio
     TypeSignature(argumentTypes = Vector(CTInteger, CTInteger), outputType = CTInteger),
     TypeSignature(argumentTypes = Vector(CTInteger, CTFloat), outputType = CTFloat),
     TypeSignature(argumentTypes = Vector(CTFloat, CTFloat), outputType = CTFloat),
+    TypeSignature(argumentTypes = Vector(CTFloat, CTInteger), outputType = CTFloat),
     TypeSignature(argumentTypes = Vector(CTDuration, CTDuration), outputType = CTDuration),
     TypeSignature(argumentTypes = Vector(CTLocalTime, CTDuration), outputType = CTLocalTime),
     TypeSignature(argumentTypes = Vector(CTTime, CTDuration), outputType = CTTime),
@@ -75,6 +75,7 @@ case class Multiply(lhs: Expression, rhs: Expression)(val position: InputPositio
     TypeSignature(argumentTypes = Vector(CTInteger, CTInteger), outputType = CTInteger),
     TypeSignature(argumentTypes = Vector(CTInteger, CTFloat), outputType = CTFloat),
     TypeSignature(argumentTypes = Vector(CTFloat, CTFloat), outputType = CTFloat),
+    TypeSignature(argumentTypes = Vector(CTFloat, CTInteger), outputType = CTFloat),
     TypeSignature(argumentTypes = Vector(CTDuration, CTFloat), outputType = CTDuration),
     TypeSignature(argumentTypes = Vector(CTDuration, CTInteger), outputType = CTDuration),
     TypeSignature(argumentTypes = Vector(CTFloat, CTDuration), outputType = CTDuration),
@@ -95,6 +96,7 @@ case class Divide(lhs: Expression, rhs: Expression)(val position: InputPosition)
     TypeSignature(argumentTypes = Vector(CTInteger, CTInteger), outputType = CTInteger),
     TypeSignature(argumentTypes = Vector(CTInteger, CTFloat), outputType = CTFloat),
     TypeSignature(argumentTypes = Vector(CTFloat, CTFloat), outputType = CTFloat),
+    TypeSignature(argumentTypes = Vector(CTFloat, CTInteger), outputType = CTFloat),
     TypeSignature(argumentTypes = Vector(CTDuration, CTFloat), outputType = CTDuration),
     TypeSignature(argumentTypes = Vector(CTDuration, CTInteger), outputType = CTDuration)
   )
@@ -112,8 +114,10 @@ case class Modulo(lhs: Expression, rhs: Expression)(val position: InputPosition)
   override val signatures = Vector(
     TypeSignature(argumentTypes = Vector(CTInteger, CTInteger), outputType = CTInteger),
     TypeSignature(argumentTypes = Vector(CTInteger, CTFloat), outputType = CTFloat),
+    TypeSignature(argumentTypes = Vector(CTFloat, CTInteger), outputType = CTFloat),
     TypeSignature(argumentTypes = Vector(CTFloat, CTFloat), outputType = CTFloat)
-  )
+
+    )
 
   override def canonicalOperatorSymbol = "%"
 }


### PR DESCRIPTION
This issue has already been fixed in neo4j-3.4 but the change was never applied
to opencypher.