### PR TITLE
Add anonymizing rewriter...

### DIFF
--- a/rewriting/src/main/scala/org/opencypher/v9_0/rewriting/rewriters/anonymizeQuery.scala
+++ b/rewriting/src/main/scala/org/opencypher/v9_0/rewriting/rewriters/anonymizeQuery.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2002-2018 Neo4j Sweden AB (http://neo4j.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opencypher.v9_0.rewriting.rewriters
+
+import org.opencypher.v9_0.ast.UnaliasedReturnItem
+import org.opencypher.v9_0.expressions._
+import org.opencypher.v9_0.util.{Rewriter, bottomUp}
+
+/**
+  * Anonymizer which renames tokens and cypher parts using some scheme. All renames have to be reproducible and
+  * unique to create a valid query.
+  *
+  * The intended usage of this rewriter is for anonymizing queries before storage, to avoid retaining domain specific
+  * information which could harm the operation or integrity of the original cypher deployment. This anonymization would
+  * execucted by 1) parsing the query, 2) running the rewriter, and 3) writing the query back to string form
+  * using the Prettifier.
+  */
+trait Anonymizer {
+  def variable(name: String): String
+  def unaliasedReturnItemName(anonymizedExpression: Expression, input: String): String
+  def label(name: String): String
+  def relationshipType(name: String): String
+  def propertyKey(name: String): String
+  def parameter(name: String): String
+}
+
+case class anonymizeQuery(anonymizer: Anonymizer) extends Rewriter {
+
+  def apply(that: AnyRef): AnyRef = instance.apply(that)
+
+  private val instance: Rewriter = bottomUp(Rewriter.lift {
+    case v: Variable => Variable(anonymizer.variable(v.name))(v.position)
+    case x: UnaliasedReturnItem => UnaliasedReturnItem(x.expression, anonymizer.unaliasedReturnItemName(x.expression, x.inputText))(x.position)
+    case x: LabelName => LabelName(anonymizer.label(x.name))(x.position)
+    case x: RelTypeName => RelTypeName(anonymizer.relationshipType(x.name))(x.position)
+    case x: PropertyKeyName => PropertyKeyName(anonymizer.propertyKey(x.name))(x.position)
+    case x: Parameter => Parameter(anonymizer.parameter(x.name), x.parameterType)(x.position)
+  })
+}

--- a/rewriting/src/test/scala/org/opencypher/v9_0/rewriting/AnonymizeQueryTest.scala
+++ b/rewriting/src/test/scala/org/opencypher/v9_0/rewriting/AnonymizeQueryTest.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2002-2018 Neo4j Sweden AB (http://neo4j.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opencypher.v9_0.rewriting
+
+import org.opencypher.v9_0.expressions.Expression
+import org.opencypher.v9_0.rewriting.rewriters.{Anonymizer, anonymizeQuery}
+import org.opencypher.v9_0.util.Rewriter
+import org.opencypher.v9_0.util.test_helpers.CypherFunSuite
+
+class AnonymizeQueryTest extends CypherFunSuite with RewriteTest {
+
+  val anonymizer = new Anonymizer {
+    override def label(name: String): String = "x"+name
+    override def relationshipType(name: String): String = "x"+name
+    override def propertyKey(name: String): String = "X"+name
+    override def variable(name: String): String = "X"+name
+    override def unaliasedReturnItemName(anonymizedExpression: Expression, input: String): String = prettifier.mkStringOf(anonymizedExpression)
+    override def parameter(name: String): String = "X"+name
+  }
+
+  val rewriterUnderTest: Rewriter = anonymizeQuery(anonymizer)
+
+  test("variable") {
+    assertRewrite("RETURN 1 AS r", "RETURN 1 AS Xr")
+    assertRewrite("WITH 1 AS k RETURN (k + k) - k AS r", "WITH 1 AS Xk RETURN (Xk + Xk) - Xk AS Xr")
+  }
+
+  test("return item") {
+    assertRewrite("WITH 1 AS k RETURN k + k", "WITH 1 AS Xk RETURN Xk + Xk")
+  }
+
+  test("label") {
+    assertRewrite("MATCH (:LABEL) RETURN count(*)", "MATCH (:xLABEL) RETURN count(*)")
+    assertRewrite("MATCH (:A:B) RETURN count(*)", "MATCH (:xA:xB) RETURN count(*)")
+    assertRewrite("MATCH (:A)--(:B) RETURN count(*)", "MATCH (:xA)--(:xB) RETURN count(*)")
+    assertRewrite("MATCH (:A)-[r*1..5]-(:B) RETURN count(*)", "MATCH (:xA)-[Xr*1..5]-(:xB) RETURN count(*)")
+    assertRewrite("MATCH (n) SET n:LABEL", "MATCH (Xn) SET Xn:xLABEL")
+  }
+
+  test("relationship type") {
+    assertRewrite("MATCH ()-[:R]-() RETURN count(*)", "MATCH ()-[:xR]-() RETURN count(*)")
+    assertRewrite("MATCH ()-[:R*2..4]-() RETURN count(*)", "MATCH ()-[:xR*2..4]-() RETURN count(*)")
+    assertRewrite("MATCH shortestPath(()-[:R*2..4]-()) RETURN count(*)", "MATCH shortestPath(()-[:xR*2..4]-()) RETURN count(*)")
+    assertRewrite("MATCH ()-[r]-() SET r:TYPE", "MATCH ()-[Xr]-() SET Xr:xTYPE")
+  }
+
+  test("property key") {
+    assertRewrite("MATCH ({p: 2}) RETURN count(*)", "MATCH ({Xp: 2}) RETURN count(*)")
+    assertRewrite("MATCH (n) SET p.n = 2", "MATCH (Xn) SET Xp.Xn = 2")
+    assertRewrite("MATCH (n) WHERE p.n > 2 RETURN 1", "MATCH (Xn) WHERE Xp.Xn > 2 RETURN 1")
+  }
+
+  test("parameter") {
+    assertRewrite("RETURN $param1 AS p1, $param2 AS p2", "RETURN $Xparam1 AS Xp1, $Xparam2 AS Xp2")
+  }
+}

--- a/rewriting/src/test/scala/org/opencypher/v9_0/rewriting/AnonymizerTestBase.scala
+++ b/rewriting/src/test/scala/org/opencypher/v9_0/rewriting/AnonymizerTestBase.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2002-2018 Neo4j Sweden AB (http://neo4j.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opencypher.v9_0.rewriting
+
+import org.opencypher.v9_0.rewriting.rewriters.Anonymizer
+import org.opencypher.v9_0.util.test_helpers.CypherFunSuite
+
+abstract class AnonymizerTestBase extends CypherFunSuite with RewriteTest {
+
+  def anonymizer: Anonymizer
+
+  test("repeatable variable") {
+    assertRename(Set("cat", "bob", "fish", "colly_flower11"), anonymizer.variable)
+  }
+
+  test("repeatable label") {
+    assertRename(Set("cat", "bob", "fish", "colly_flower11"), anonymizer.label)
+  }
+
+  test("repeatable relationshipType") {
+    assertRename(Set("cat", "bob", "fish", "colly_flower11"), anonymizer.relationshipType)
+  }
+
+  test("repeatable propertyKey") {
+    assertRename(Set("cat", "bob", "fish", "colly_flower11"), anonymizer.propertyKey)
+  }
+
+  test("repeatable parameter") {
+    assertRename(Set("cat", "bob", "fish", "colly_flower11"), anonymizer.parameter)
+  }
+
+  private def assertRename(names: Set[String], rename: String => String): Unit = {
+    val anons = names.map(anonymizer.variable)
+    anons.size should be(4)
+    anons should be(names.map(anonymizer.variable))
+  }
+}

--- a/rewriting/src/test/scala/org/opencypher/v9_0/rewriting/AnonymizerTestBase.scala
+++ b/rewriting/src/test/scala/org/opencypher/v9_0/rewriting/AnonymizerTestBase.scala
@@ -43,8 +43,8 @@ abstract class AnonymizerTestBase extends CypherFunSuite with RewriteTest {
   }
 
   private def assertRename(names: Set[String], rename: String => String): Unit = {
-    val anons = names.map(anonymizer.variable)
+    val anons = names.map(rename)
     anons.size should be(4)
-    anons should be(names.map(anonymizer.variable))
+    anons should be(names.map(rename))
   }
 }

--- a/rewriting/src/test/scala/org/opencypher/v9_0/rewriting/DesugarDesugaredMapProjectionTest.scala
+++ b/rewriting/src/test/scala/org/opencypher/v9_0/rewriting/DesugarDesugaredMapProjectionTest.scala
@@ -15,12 +15,12 @@
  */
 package org.opencypher.v9_0.rewriting
 
-import org.opencypher.v9_0.util.test_helpers.CypherFunSuite
-import org.opencypher.v9_0.util.{Rewriter, inSequence}
 import org.opencypher.v9_0.ast.Statement
 import org.opencypher.v9_0.ast.semantics.{SemanticState, SyntaxExceptionCreator}
 import org.opencypher.v9_0.parser.ParserFixture.parser
 import org.opencypher.v9_0.rewriting.rewriters.{desugarMapProjection, normalizeWithAndReturnClauses, recordScopes}
+import org.opencypher.v9_0.util.test_helpers.CypherFunSuite
+import org.opencypher.v9_0.util.{Rewriter, inSequence}
 
 class DesugarDesugaredMapProjectionTest extends CypherFunSuite {
 


### PR DESCRIPTION
...which renames tokens and cypher parts using some scheme. All renames
have to be reproducible and unique to create a valid query.

The intended usage of this rewriter is for anonymizing queries before
storage, to avoid retaining domain specific information which could harm
the operation or integrity of the original cypher deployment. This
anonymization would execucted by

  1) parsing the query
  2) running the rewriter
  3) writing the query back to string form using the Prettifier.