### PR TITLE
Solve bug in semantic checking of list comprehension

### DIFF
--- a/ast/src/main/scala/org/opencypher/v9_0/ast/semantics/SemanticExpressionCheck.scala
+++ b/ast/src/main/scala/org/opencypher/v9_0/ast/semantics/SemanticExpressionCheck.scala
@@ -645,8 +645,12 @@ object SemanticExpressionCheck extends SemanticAnalysisTooling {
           val outerTypes: TypeGenerator = types(e)(_).wrapInList
           specifyType(outerTypes, x)
         }
-      case None =>
+      case None => withScopedState {
+        // Even if there is no usage of that variable, we need to declare it, to not confuse the Namespacer
+        declareVariable(x.variable, FilteringExpressions.possibleInnerTypes(x))
+      } chain {
         specifyType(types(x.expression), x)
+      }
     }
 }
 

--- a/ast/src/test/scala/org/opencypher/v9_0/ast/semantics/ListComprehensionTest.scala
+++ b/ast/src/test/scala/org/opencypher/v9_0/ast/semantics/ListComprehensionTest.scala
@@ -50,4 +50,14 @@ class ListComprehensionTest extends SemanticFunSuite {
     result.errors should equal(Seq(error))
     result.state.symbol("x") should equal(None)
   }
+
+  test("should declare variables in list comprehension without predicate") {
+    val listComprehension = ListComprehension(Variable("x")(DummyPosition(2)), dummyExpression, None, None)(DummyPosition(0))
+    val result = SemanticExpressionCheck.simple(listComprehension)(SemanticState.clean)
+    result.errors shouldBe empty
+    // x should not be in the outer scope
+    result.state.symbol("x") should equal(None)
+    // x should be in the inner scope
+    result.state.scopeTree.children.head.symbolTable.keys should contain("x")
+  }
 }


### PR DESCRIPTION
Variables in list comprehension need to be declared in semantic checking even if they don't have a predicate. Otherwise  queries with ambiguous variables of the form

```
 RETURN
        [x IN [...] WHERE ... ] AS res1,
        [x IN [...] WHERE ... ] AS res2,
        [x IN [...]] AS res3
```

will throw an `key not found: SymbolUse(x@...)`  for the last `x`.