### PR TITLE
Improve error message for illagal variable access in WITH/RETURN

### DIFF
--- a/ast/src/main/scala/org/opencypher/v9_0/ast/semantics/SemanticError.scala
+++ b/ast/src/main/scala/org/opencypher/v9_0/ast/semantics/SemanticError.scala
@@ -21,12 +21,17 @@ sealed trait SemanticErrorDef {
   def msg: String
   def position: InputPosition
   def references: Seq[InputPosition]
+  def withMsg(message: String): SemanticErrorDef
 }
 
-final case class SemanticError(msg: String, position: InputPosition, references: InputPosition*) extends SemanticErrorDef
+final case class SemanticError(msg: String, position: InputPosition, references: InputPosition*) extends SemanticErrorDef {
+  override def withMsg(message: String): SemanticError = SemanticError(message, position, references:_*)
+}
 
 sealed trait UnsupportedOpenCypher extends SemanticErrorDef
 
 final case class FeatureError(msg: String, position: InputPosition) extends UnsupportedOpenCypher {
-  override def references = Seq.empty
+  override def references: Seq[InputPosition] = Seq.empty
+
+  override def withMsg(message: String): FeatureError = copy(msg = message)
 }

--- a/frontend/src/test/scala/org/opencypher/v9_0/frontend/SemanticAnalysisErrorMessagesTest.scala
+++ b/frontend/src/test/scala/org/opencypher/v9_0/frontend/SemanticAnalysisErrorMessagesTest.scala
@@ -1,0 +1,159 @@
+/*
+ * Copyright © 2002-2018 Neo4j Sweden AB (http://neo4j.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opencypher.v9_0.frontend
+
+import org.opencypher.v9_0.ast.AstConstructionTestSupport
+import org.opencypher.v9_0.frontend.phases._
+import org.opencypher.v9_0.util.symbols._
+import org.opencypher.v9_0.util.test_helpers.CypherFunSuite
+
+/**
+  * Opposed to `SemanticAnalysisTest` this does not focus on whether
+  * something actually passes semantic analysis or not, but rather on helpful
+  * error messages.
+  */
+class SemanticAnalysisErrorMessagesTest extends CypherFunSuite with AstConstructionTestSupport {
+
+  // This test invokes SemanticAnalysis twice because that's what the production pipeline does
+  val pipeline = Parsing andThen SemanticAnalysis(warn = true) andThen SemanticAnalysis(warn = false)
+
+  // positive tests that we get the error message
+  // "In a WITH/RETURN with DISTINCT or an aggregation, it is not possible to access variables declared before the WITH/RETURN"
+
+  test("Should give helpful error when accessing illegal variable in ORDER BY after WITH DISTINCT") {
+    val query = "MATCH (p) WITH DISTINCT p.email AS mail ORDER BY p.name RETURN mail AS mail"
+
+    val startState = initStartState(query, Map.empty)
+
+    pipeline.transform(startState, ErrorCollectingContext)
+
+    ErrorCollectingContext.errors.map(_.msg) should equal(List("In a WITH/RETURN with DISTINCT or an aggregation, it is not possible to access variables declared before the WITH/RETURN: p"))
+  }
+
+  test("Should give helpful error when accessing illegal variable in ORDER BY after WITH with aggregation") {
+    val query = "MATCH (p) WITH collect(p.email) AS mail ORDER BY p.name RETURN mail AS mail"
+
+    val startState = initStartState(query, Map.empty)
+
+    pipeline.transform(startState, ErrorCollectingContext)
+
+    ErrorCollectingContext.errors.map(_.msg) should equal(List("In a WITH/RETURN with DISTINCT or an aggregation, it is not possible to access variables declared before the WITH/RETURN: p"))
+  }
+
+  test("Should give helpful error when accessing illegal variable in ORDER BY after RETURN DISTINCT") {
+    val query = "MATCH (p) RETURN DISTINCT p.email AS mail ORDER BY p.name"
+
+    val startState = initStartState(query, Map.empty)
+
+    pipeline.transform(startState, ErrorCollectingContext)
+
+    ErrorCollectingContext.errors.map(_.msg) should equal(List("In a WITH/RETURN with DISTINCT or an aggregation, it is not possible to access variables declared before the WITH/RETURN: p"))
+  }
+
+  test("Should give helpful error when accessing illegal variable in ORDER BY after RETURN with aggregation") {
+    val query = "MATCH (p) RETURN collect(p.email) AS mail ORDER BY p.name"
+
+    val startState = initStartState(query, Map.empty)
+
+    pipeline.transform(startState, ErrorCollectingContext)
+
+    ErrorCollectingContext.errors.map(_.msg) should equal(List("In a WITH/RETURN with DISTINCT or an aggregation, it is not possible to access variables declared before the WITH/RETURN: p"))
+  }
+
+  test("Should give helpful error when accessing illegal variable in WHERE after WITH DISTINCT") {
+    val query = "MATCH (p) WITH DISTINCT p.email AS mail WHERE exists(p.name) RETURN mail AS mail"
+
+    val startState = initStartState(query, Map.empty)
+
+    pipeline.transform(startState, ErrorCollectingContext)
+
+    ErrorCollectingContext.errors.map(_.msg) should equal(List("In a WITH/RETURN with DISTINCT or an aggregation, it is not possible to access variables declared before the WITH/RETURN: p"))
+  }
+
+  test("Should give helpful error when accessing illegal variable in WHERE after WITH with aggregation") {
+    val query = "MATCH (p) WITH collect(p.email) AS mail WHERE exists(p.name) RETURN mail AS mail"
+
+    val startState = initStartState(query, Map.empty)
+
+    pipeline.transform(startState, ErrorCollectingContext)
+
+    ErrorCollectingContext.errors.map(_.msg) should equal(List("In a WITH/RETURN with DISTINCT or an aggregation, it is not possible to access variables declared before the WITH/RETURN: p"))
+  }
+
+  // negative tests that we do not get this error message otherwise
+
+  test("Should not invent helpful error when accessing undefined variable in ORDER BY after WITH DISTINCT") {
+    val query = "MATCH (p) WITH DISTINCT p.email AS mail ORDER BY q.name RETURN mail AS mail"
+
+    val startState = initStartState(query, Map.empty)
+
+    pipeline.transform(startState, ErrorCollectingContext)
+
+    ErrorCollectingContext.errors.map(_.msg) should equal(List("Variable `q` not defined"))
+  }
+  test("Should not invent helpful error when accessing undefined variable in ORDER BY after WITH with aggregation") {
+    val query = "MATCH (p) WITH collect(p.email) AS mail ORDER BY q.name RETURN mail AS mail"
+
+    val startState = initStartState(query, Map.empty)
+
+    pipeline.transform(startState, ErrorCollectingContext)
+
+    ErrorCollectingContext.errors.map(_.msg) should equal(List("Variable `q` not defined"))
+  }
+
+  test("Should not invent helpful error when accessing undefined variable in ORDER BY after RETURN DISTINCT") {
+    val query = "MATCH (p) RETURN DISTINCT p.email AS mail ORDER BY q.name"
+
+    val startState = initStartState(query, Map.empty)
+
+    pipeline.transform(startState, ErrorCollectingContext)
+
+    ErrorCollectingContext.errors.map(_.msg) should equal(List("Variable `q` not defined"))
+  }
+
+  test("Should not invent helpful error when accessing undefined variable in ORDER BY after RETURN with aggregation") {
+    val query = "MATCH (p) RETURN collect(p.email) AS mail ORDER BY q.name"
+
+    val startState = initStartState(query, Map.empty)
+
+    pipeline.transform(startState, ErrorCollectingContext)
+
+    ErrorCollectingContext.errors.map(_.msg) should equal(List("Variable `q` not defined"))
+  }
+
+  test("Should not invent helpful error when accessing undefined variable in WHERE after WITH DISTINCT") {
+    val query = "MATCH (p) WITH DISTINCT p.email AS mail WHERE exists(q.name) RETURN mail AS mail"
+
+    val startState = initStartState(query, Map.empty)
+
+    pipeline.transform(startState, ErrorCollectingContext)
+
+    ErrorCollectingContext.errors.map(_.msg) should equal(List("Variable `q` not defined"))
+  }
+
+  test("Should not invent helpful error when accessing undefined variable in WHERE after WITH with aggregation") {
+    val query = "MATCH (p) WITH collect(p.email) AS mail WHERE exists(q.name) RETURN mail AS mail"
+
+    val startState = initStartState(query, Map.empty)
+
+    pipeline.transform(startState, ErrorCollectingContext)
+
+    ErrorCollectingContext.errors.map(_.msg) should equal(List("Variable `q` not defined"))
+  }
+
+  private def initStartState(query: String, initialFields: Map[String, CypherType]) =
+    InitialState(query, None, NoPlannerName, initialFields)
+}

--- a/frontend/src/test/scala/org/opencypher/v9_0/frontend/SemanticAnalysisTest.scala
+++ b/frontend/src/test/scala/org/opencypher/v9_0/frontend/SemanticAnalysisTest.scala
@@ -75,46 +75,6 @@ class SemanticAnalysisTest extends CypherFunSuite with AstConstructionTestSuppor
     ErrorCollectingContext.errors.map(_.msg) should equal(List("Variable `n` already declared"))
   }
 
-  test("Should give helpful error when accessing illegal variable in ORDER BY after WITH DISTINCT") {
-    val query = "MATCH (p) WITH DISTINCT p.email AS mail ORDER BY p.name RETURN mail AS mail"
-
-    val startState = initStartState(query, Map.empty)
-
-    pipeline.transform(startState, ErrorCollectingContext)
-
-    ErrorCollectingContext.errors.map(_.msg) should equal(List("In a WITH/RETURN with DISTINCT or an aggregation, it is not possible to access variables declared before the WITH/RETURN: p"))
-  }
-
-  test("Should give helpful error when accessing illegal variable in WHERE after WITH DISTINCT") {
-    val query = "MATCH (p) WITH DISTINCT p.email AS mail WHERE exists(p.name) RETURN mail AS mail"
-
-    val startState = initStartState(query, Map.empty)
-
-    pipeline.transform(startState, ErrorCollectingContext)
-
-    ErrorCollectingContext.errors.map(_.msg) should equal(List("In a WITH/RETURN with DISTINCT or an aggregation, it is not possible to access variables declared before the WITH/RETURN: p"))
-  }
-
-  test("Should give helpful error when accessing illegal variable in ORDER BY after WITH with aggregation") {
-    val query = "MATCH (p) WITH collect(p.email) AS mail ORDER BY p.name RETURN mail AS mail"
-
-    val startState = initStartState(query, Map.empty)
-
-    pipeline.transform(startState, ErrorCollectingContext)
-
-    ErrorCollectingContext.errors.map(_.msg) should equal(List("In a WITH/RETURN with DISTINCT or an aggregation, it is not possible to access variables declared before the WITH/RETURN: p"))
-  }
-
-  test("Should give helpful error when accessing illegal variable in WHERE after WITH with aggregation") {
-    val query = "MATCH (p) WITH collect(p.email) AS mail WHERE exists(p.name) RETURN mail AS mail"
-
-    val startState = initStartState(query, Map.empty)
-
-    pipeline.transform(startState, ErrorCollectingContext)
-
-    ErrorCollectingContext.errors.map(_.msg) should equal(List("In a WITH/RETURN with DISTINCT or an aggregation, it is not possible to access variables declared before the WITH/RETURN: p"))
-  }
-
   private def initStartState(query: String, initialFields: Map[String, CypherType]) =
     InitialState(query, None, NoPlannerName, initialFields)
 }

--- a/frontend/src/test/scala/org/opencypher/v9_0/frontend/SemanticAnalysisTest.scala
+++ b/frontend/src/test/scala/org/opencypher/v9_0/frontend/SemanticAnalysisTest.scala
@@ -75,6 +75,46 @@ class SemanticAnalysisTest extends CypherFunSuite with AstConstructionTestSuppor
     ErrorCollectingContext.errors.map(_.msg) should equal(List("Variable `n` already declared"))
   }
 
+  test("Should give helpful error when accessing illegal variable in ORDER BY after WITH DISTINCT") {
+    val query = "MATCH (p) WITH DISTINCT p.email AS mail ORDER BY p.name RETURN mail AS mail"
+
+    val startState = initStartState(query, Map.empty)
+
+    pipeline.transform(startState, ErrorCollectingContext)
+
+    ErrorCollectingContext.errors.map(_.msg) should equal(List("In a WITH/RETURN with DISTINCT or an aggregation, it is not possible to access variables declared before the WITH/RETURN: p"))
+  }
+
+  test("Should give helpful error when accessing illegal variable in WHERE after WITH DISTINCT") {
+    val query = "MATCH (p) WITH DISTINCT p.email AS mail WHERE exists(p.name) RETURN mail AS mail"
+
+    val startState = initStartState(query, Map.empty)
+
+    pipeline.transform(startState, ErrorCollectingContext)
+
+    ErrorCollectingContext.errors.map(_.msg) should equal(List("In a WITH/RETURN with DISTINCT or an aggregation, it is not possible to access variables declared before the WITH/RETURN: p"))
+  }
+
+  test("Should give helpful error when accessing illegal variable in ORDER BY after WITH with aggregation") {
+    val query = "MATCH (p) WITH collect(p.email) AS mail ORDER BY p.name RETURN mail AS mail"
+
+    val startState = initStartState(query, Map.empty)
+
+    pipeline.transform(startState, ErrorCollectingContext)
+
+    ErrorCollectingContext.errors.map(_.msg) should equal(List("In a WITH/RETURN with DISTINCT or an aggregation, it is not possible to access variables declared before the WITH/RETURN: p"))
+  }
+
+  test("Should give helpful error when accessing illegal variable in WHERE after WITH with aggregation") {
+    val query = "MATCH (p) WITH collect(p.email) AS mail WHERE exists(p.name) RETURN mail AS mail"
+
+    val startState = initStartState(query, Map.empty)
+
+    pipeline.transform(startState, ErrorCollectingContext)
+
+    ErrorCollectingContext.errors.map(_.msg) should equal(List("In a WITH/RETURN with DISTINCT or an aggregation, it is not possible to access variables declared before the WITH/RETURN: p"))
+  }
+
   private def initStartState(query: String, initialFields: Map[String, CypherType]) =
     InitialState(query, None, NoPlannerName, initialFields)
 }

--- a/rewriting/src/test/scala/org/opencypher/v9_0/rewriting/NormalizeWithAndReturnClausesTest.scala
+++ b/rewriting/src/test/scala/org/opencypher/v9_0/rewriting/NormalizeWithAndReturnClausesTest.scala
@@ -611,13 +611,13 @@ class NormalizeWithAndReturnClausesTest extends CypherFunSuite with RewriteTest 
       """MATCH (n)
         |WITH DISTINCT n.prop AS prop ORDER BY n.foo
         |RETURN prop AS prop
-      """.stripMargin, "Variable `n` not defined (line 2, column 39 (offset: 48))")
+      """.stripMargin, "In a WITH/RETURN with DISTINCT or an aggregation, it is not possible to access variables declared before the WITH/RETURN: n (line 2, column 39 (offset: 48))")
 
     assertNotRewritittenAndSemanticErrors(
       """MATCH (n)
         |WITH n.prop AS prop, collect(n.foo) AS foos ORDER BY n.foo
         |RETURN prop AS prop, foos AS foos
-      """.stripMargin, "Variable `n` not defined (line 2, column 54 (offset: 63))")
+      """.stripMargin, "In a WITH/RETURN with DISTINCT or an aggregation, it is not possible to access variables declared before the WITH/RETURN: n (line 2, column 54 (offset: 63))")
   }
 
   test("RETURN: aggregating: does not change grouping set when introducing aliases for ORDER BY with non-grouping expression") {
@@ -625,12 +625,12 @@ class NormalizeWithAndReturnClausesTest extends CypherFunSuite with RewriteTest 
     assertNotRewritittenAndSemanticErrors(
       """MATCH (n)
         |RETURN DISTINCT n.prop AS prop ORDER BY n.foo
-      """.stripMargin, "Variable `n` not defined (line 2, column 41 (offset: 50))")
+      """.stripMargin, "In a WITH/RETURN with DISTINCT or an aggregation, it is not possible to access variables declared before the WITH/RETURN: n (line 2, column 41 (offset: 50))")
 
     assertNotRewritittenAndSemanticErrors(
       """MATCH (n)
         |RETURN n.prop AS prop, collect(n.foo) AS foos ORDER BY n.foo
-      """.stripMargin, "Variable `n` not defined (line 2, column 56 (offset: 65))")
+      """.stripMargin, "In a WITH/RETURN with DISTINCT or an aggregation, it is not possible to access variables declared before the WITH/RETURN: n (line 2, column 56 (offset: 65))")
   }
 
   test("aggregating: does not change grouping set when introducing aliases for WHERE with non-grouping expression") {
@@ -639,14 +639,14 @@ class NormalizeWithAndReturnClausesTest extends CypherFunSuite with RewriteTest 
       """MATCH (n)
         |WITH DISTINCT n.prop AS prop WHERE n.foo
         |RETURN prop AS prop
-      """.stripMargin, "Variable `n` not defined (line 2, column 36 (offset: 45))")
+      """.stripMargin, "In a WITH/RETURN with DISTINCT or an aggregation, it is not possible to access variables declared before the WITH/RETURN: n (line 2, column 36 (offset: 45))")
 
 
     assertNotRewritittenAndSemanticErrors(
       """MATCH (n)
         |WITH n.prop AS prop, collect(n.foo) AS foos WHERE n.foo
         |RETURN prop AS prop, foos AS foos
-      """.stripMargin, "Variable `n` not defined (line 2, column 51 (offset: 60))")
+      """.stripMargin, "In a WITH/RETURN with DISTINCT or an aggregation, it is not possible to access variables declared before the WITH/RETURN: n (line 2, column 51 (offset: 60))")
   }
 
   // Below: unordered, exploratory tests


### PR DESCRIPTION
Queries like

```
MATCH (a) RETURN DISTINCT a.name ORDER BY a.age
```

would fail with a non-helpful error message "Variable `a` not defined"
This is changed to

```
In a WITH/RETURN with DISTINCT or an aggregation, it is not possible
to access variables declared before the WITH/RETURN: p
```