### PR TITLE
Update comparison semantic checking

### DIFF
--- a/ast/src/main/scala/org/opencypher/v9_0/ast/semantics/SemanticExpressionCheck.scala
+++ b/ast/src/main/scala/org/opencypher/v9_0/ast/semantics/SemanticExpressionCheck.scala
@@ -153,29 +153,16 @@ object SemanticExpressionCheck extends SemanticAnalysisTooling {
           checkTypes(x, x.signatures)
 
       case x:LessThan =>
-        check(ctx, x.arguments) chain ((state:SemanticState) =>
-          //According to spec comparing unrelated types should yield null not error
-          if (state.cypher9ComparabilitySemantics) expectType(CTBoolean.covariant, x)(state)
-          else checkTypes(x, x.signatures)(state))
+        check(ctx, x.arguments) chain checkComparison(x)
 
       case x:LessThanOrEqual =>
-        check(ctx, x.arguments) chain ((state:SemanticState) =>
-          //According to spec comparing unrelated types should yield null not error
-          if (state.cypher9ComparabilitySemantics) expectType(CTBoolean.covariant, x)(state)
-          else checkTypes(x, x.signatures)(state))
+        check(ctx, x.arguments) chain checkComparison(x)
 
       case x:GreaterThan =>
-        check(ctx, x.arguments) chain ((state:SemanticState) =>
-          //According to spec comparing unrelated types should yield null not error
-          //According to spec comparing unrelated types should yield null not error
-          if (state.cypher9ComparabilitySemantics) expectType(CTBoolean.covariant, x)(state)
-          else checkTypes(x, x.signatures)(state))
+        check(ctx, x.arguments) chain checkComparison(x)
 
       case x:GreaterThanOrEqual =>
-        check(ctx, x.arguments) chain ((state:SemanticState) =>
-          //According to spec comparing unrelated types should yield null not error
-          if (state.cypher9ComparabilitySemantics) expectType(CTBoolean.covariant, x)(state)
-          else checkTypes(x, x.signatures)(state))
+        check(ctx, x.arguments) chain checkComparison(x)
 
       case x:PartialPredicate[_] =>
         check(ctx, x.coveredPredicate)
@@ -659,5 +646,16 @@ object SemanticExpressionCheck extends SemanticAnalysisTooling {
         specifyType(types(x.expression), x)
       }
     }
+
+  private def checkComparison(x: InequalityExpression): SemanticCheck = (state: SemanticState) => {
+    //According to spec comparing unrelated types should yield null not error
+    if (state.cypher9ComparabilitySemantics) {
+      specifyType(CTBoolean, x)(state) match {
+        case Left(err) => SemanticCheckResult(state, List(err))
+        case Right(s) => SemanticCheckResult(s, List.empty)
+      }
+    }
+    else checkTypes(x, x.signatures)(state)
+  }
 }
 

--- a/ast/src/main/scala/org/opencypher/v9_0/ast/semantics/SemanticExpressionCheck.scala
+++ b/ast/src/main/scala/org/opencypher/v9_0/ast/semantics/SemanticExpressionCheck.scala
@@ -153,25 +153,32 @@ object SemanticExpressionCheck extends SemanticAnalysisTooling {
           checkTypes(x, x.signatures)
 
       case x:LessThan =>
-        check(ctx, x.arguments) chain
-          checkTypes(x, x.signatures)
+        check(ctx, x.arguments) chain ((state:SemanticState) =>
+          //According to spec comparing unrelated types should yield null not error
+          if (state.cypher9ComparabilitySemantics) expectType(CTBoolean.covariant, x)(state)
+          else checkTypes(x, x.signatures)(state))
 
       case x:LessThanOrEqual =>
-        check(ctx, x.arguments) chain
-          checkTypes(x, x.signatures)
+        check(ctx, x.arguments) chain ((state:SemanticState) =>
+          //According to spec comparing unrelated types should yield null not error
+          if (state.cypher9ComparabilitySemantics) expectType(CTBoolean.covariant, x)(state)
+          else checkTypes(x, x.signatures)(state))
 
       case x:GreaterThan =>
-        check(ctx, x.arguments) chain
-          checkTypes(x, x.signatures)
+        check(ctx, x.arguments) chain ((state:SemanticState) =>
+          //According to spec comparing unrelated types should yield null not error
+          //According to spec comparing unrelated types should yield null not error
+          if (state.cypher9ComparabilitySemantics) expectType(CTBoolean.covariant, x)(state)
+          else checkTypes(x, x.signatures)(state))
 
       case x:GreaterThanOrEqual =>
-        check(ctx, x.arguments) chain
-          checkTypes(x, x.signatures)
+        check(ctx, x.arguments) chain ((state:SemanticState) =>
+          //According to spec comparing unrelated types should yield null not error
+          if (state.cypher9ComparabilitySemantics) expectType(CTBoolean.covariant, x)(state)
+          else checkTypes(x, x.signatures)(state))
 
       case x:PartialPredicate[_] =>
         check(ctx, x.coveredPredicate)
-
-      //
 
       case x:CaseExpression =>
         val possibleTypes = unionOfTypes(x.possibleExpressions)

--- a/ast/src/main/scala/org/opencypher/v9_0/ast/semantics/SemanticExpressionCheck.scala
+++ b/ast/src/main/scala/org/opencypher/v9_0/ast/semantics/SemanticExpressionCheck.scala
@@ -86,8 +86,7 @@ object SemanticExpressionCheck extends SemanticAnalysisTooling {
           checkTypes(x, x.signatures)
 
       case x:Equals =>
-        check(ctx, x.arguments) chain
-          checkTypes(x, x.signatures)
+        check(ctx, x.arguments) chain checkComparison(x, x.signatures)
 
       case x:Equivalent =>
         requireCypher10Support("`~` (equivalence)", x.position) chain
@@ -95,8 +94,7 @@ object SemanticExpressionCheck extends SemanticAnalysisTooling {
           checkTypes(x, x.signatures)
 
       case x:NotEquals =>
-        check(ctx, x.arguments) chain
-          checkTypes(x, x.signatures)
+        check(ctx, x.arguments) chain checkComparison(x, x.signatures)
 
       case x:InvalidNotEquals =>
         SemanticError(
@@ -153,16 +151,16 @@ object SemanticExpressionCheck extends SemanticAnalysisTooling {
           checkTypes(x, x.signatures)
 
       case x:LessThan =>
-        check(ctx, x.arguments) chain checkComparison(x)
+        check(ctx, x.arguments) chain checkComparison(x, x.signatures)
 
       case x:LessThanOrEqual =>
-        check(ctx, x.arguments) chain checkComparison(x)
+        check(ctx, x.arguments) chain checkComparison(x, x.signatures)
 
       case x:GreaterThan =>
-        check(ctx, x.arguments) chain checkComparison(x)
+        check(ctx, x.arguments) chain checkComparison(x, x.signatures)
 
       case x:GreaterThanOrEqual =>
-        check(ctx, x.arguments) chain checkComparison(x)
+        check(ctx, x.arguments) chain checkComparison(x, x.signatures)
 
       case x:PartialPredicate[_] =>
         check(ctx, x.coveredPredicate)
@@ -647,7 +645,7 @@ object SemanticExpressionCheck extends SemanticAnalysisTooling {
       }
     }
 
-  private def checkComparison(x: InequalityExpression): SemanticCheck = (state: SemanticState) => {
+  private def checkComparison(x: Expression, signatures: Seq[TypeSignature]): SemanticCheck = (state: SemanticState) => {
     //According to spec comparing unrelated types should yield null not error
     if (state.cypher9ComparabilitySemantics) {
       specifyType(CTBoolean, x)(state) match {
@@ -655,7 +653,7 @@ object SemanticExpressionCheck extends SemanticAnalysisTooling {
         case Right(s) => SemanticCheckResult(s, List.empty)
       }
     }
-    else checkTypes(x, x.signatures)(state)
+    else checkTypes(x, signatures)(state)
   }
 }
 

--- a/ast/src/main/scala/org/opencypher/v9_0/ast/semantics/SemanticState.scala
+++ b/ast/src/main/scala/org/opencypher/v9_0/ast/semantics/SemanticState.scala
@@ -17,14 +17,10 @@ package org.opencypher.v9_0.ast.semantics
 
 import org.opencypher.v9_0.ast.ASTAnnotationMap
 import org.opencypher.v9_0.ast.semantics.SemanticState.ScopeLocation
-import org.opencypher.v9_0.expressions.Expression
-import org.opencypher.v9_0.expressions.LogicalVariable
-import org.opencypher.v9_0.expressions.Variable
+import org.opencypher.v9_0.expressions.{Expression, LogicalVariable, Variable}
 import org.opencypher.v9_0.util._
-import org.opencypher.v9_0.util.helpers.TreeElem
-import org.opencypher.v9_0.util.helpers.TreeZipper
-import org.opencypher.v9_0.util.symbols.TypeSpec
-import org.opencypher.v9_0.util.symbols._
+import org.opencypher.v9_0.util.helpers.{TreeElem, TreeZipper}
+import org.opencypher.v9_0.util.symbols.{TypeSpec, _}
 
 import scala.collection.immutable.HashMap
 import scala.language.postfixOps
@@ -246,8 +242,8 @@ case class SemanticState(currentScope: ScopeLocation,
                          notifications: Set[InternalNotification] = Set.empty,
                          features: Set[SemanticFeature] = Set.empty,
                          initialWith: Boolean = false,
-                         declareVariablesToSuppressDuplicateErrors: Boolean = true
-                        ) {
+                         declareVariablesToSuppressDuplicateErrors: Boolean = true,
+                         cypher9ComparabilitySemantics: Boolean = false) {
 
   def recogniseInitialWith: SemanticState = copy(initialWith = true)
 
@@ -267,6 +263,8 @@ case class SemanticState(currentScope: ScopeLocation,
 
   def importValuesFromScope(scope: Scope, exclude: Set[String] = Set.empty): SemanticState =
     copy(currentScope = currentScope.importValuesFromScope(scope, exclude))
+
+  def withCypher9ComparabilitySemantics(cypher9ComparabilitySemantics: Boolean): SemanticState = copy(cypher9ComparabilitySemantics = cypher9ComparabilitySemantics)
 
   def mergeSymbolPositionsFromScope(scope: Scope, exclude: Set[String] = Set.empty): SemanticState =
     copy(currentScope = currentScope.mergeSymbolPositionsFromScope(scope, exclude))

--- a/ast/src/test/scala/org/opencypher/v9_0/ast/semantics/EqualsTest.scala
+++ b/ast/src/test/scala/org/opencypher/v9_0/ast/semantics/EqualsTest.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2002-2018 Neo4j Sweden AB (http://neo4j.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opencypher.v9_0.ast.semantics
+
+import org.opencypher.v9_0.expressions
+import org.opencypher.v9_0.util.DummyPosition
+import org.opencypher.v9_0.util.symbols._
+
+class EqualsTest extends InfixExpressionTestBase(expressions.Equals(_, _)(DummyPosition(0))) {
+  private val types = List(CTList(CTAny), CTInteger, CTFloat, CTNumber, CTNode, CTPath, CTRelationship, CTMap, CTPoint,
+                   CTDate, CTDuration, CTBoolean, CTString, CTDateTime, CTGeometry, CTLocalDateTime, CTLocalTime, CTTime)
+
+  test("should support equality checks among all types with Cypher 9 comparison semantics") {
+    types.foreach { t1 =>
+      types.foreach { t2 =>
+        testValidTypes(t1, t2, useCypher9ComparisonSemantics = true)(CTBoolean)
+      }
+    }
+  }
+}

--- a/ast/src/test/scala/org/opencypher/v9_0/ast/semantics/GreaterThanOrEqualTest.scala
+++ b/ast/src/test/scala/org/opencypher/v9_0/ast/semantics/GreaterThanOrEqualTest.scala
@@ -15,10 +15,9 @@
  */
 package org.opencypher.v9_0.ast.semantics
 
+import org.opencypher.v9_0.expressions
 import org.opencypher.v9_0.util.DummyPosition
 import org.opencypher.v9_0.util.symbols._
-import org.opencypher.v9_0.expressions
-import org.opencypher.v9_0.expressions.GreaterThanOrEqual
 
 class GreaterThanOrEqualTest extends InfixExpressionTestBase(expressions.GreaterThanOrEqual(_, _)(DummyPosition(0))) {
 
@@ -50,5 +49,17 @@ class GreaterThanOrEqualTest extends InfixExpressionTestBase(expressions.Greater
     testInvalidApplication(CTNode, CTInteger)("Type mismatch: expected Float, Integer, Point, String, Date, Time, LocalTime, LocalDateTime or DateTime but was Node")
     testInvalidApplication(CTInteger, CTNode)("Type mismatch: expected Float or Integer but was Node")
     testInvalidApplication(CTDuration, CTDuration)("Type mismatch: expected Float, Integer, Point, String, Date, Time, LocalTime, LocalDateTime or DateTime but was Duration")
+  }
+
+  test("should support comparing all types with Cypher 9 comparison semantics") {
+    val types = List(CTList(CTAny), CTInteger, CTFloat, CTNumber, CTNode, CTPath, CTRelationship, CTMap, CTPoint,
+                     CTDate, CTDuration, CTBoolean, CTString, CTDateTime, CTGeometry, CTLocalDateTime, CTLocalTime,
+                     CTTime)
+
+    types.foreach { t1 =>
+      types.foreach { t2 =>
+        testValidTypes(t1, t2, useCypher9ComparisonSemantics = true)(CTBoolean)
+      }
+    }
   }
 }

--- a/ast/src/test/scala/org/opencypher/v9_0/ast/semantics/GreaterThanTest.scala
+++ b/ast/src/test/scala/org/opencypher/v9_0/ast/semantics/GreaterThanTest.scala
@@ -15,10 +15,9 @@
  */
 package org.opencypher.v9_0.ast.semantics
 
+import org.opencypher.v9_0.expressions
 import org.opencypher.v9_0.util.DummyPosition
 import org.opencypher.v9_0.util.symbols._
-import org.opencypher.v9_0.expressions
-import org.opencypher.v9_0.expressions.GreaterThan
 
 class GreaterThanTest extends InfixExpressionTestBase(expressions.GreaterThan(_, _)(DummyPosition(0))) {
 
@@ -50,5 +49,17 @@ class GreaterThanTest extends InfixExpressionTestBase(expressions.GreaterThan(_,
     testInvalidApplication(CTNode, CTInteger)("Type mismatch: expected Float, Integer, Point, String, Date, Time, LocalTime, LocalDateTime or DateTime but was Node")
     testInvalidApplication(CTInteger, CTNode)("Type mismatch: expected Float or Integer but was Node")
     testInvalidApplication(CTDuration, CTDuration)("Type mismatch: expected Float, Integer, Point, String, Date, Time, LocalTime, LocalDateTime or DateTime but was Duration")
+  }
+
+  test("should support comparing all types with Cypher 9 comparison semantics") {
+    val types = List(CTList(CTAny), CTInteger, CTFloat, CTNumber, CTNode, CTPath, CTRelationship, CTMap, CTPoint,
+                     CTDate, CTDuration, CTBoolean, CTString, CTDateTime, CTGeometry, CTLocalDateTime, CTLocalTime,
+                     CTTime)
+
+    types.foreach { t1 =>
+      types.foreach { t2 =>
+        testValidTypes(t1, t2, useCypher9ComparisonSemantics = true)(CTBoolean)
+      }
+    }
   }
 }

--- a/ast/src/test/scala/org/opencypher/v9_0/ast/semantics/InfixExpressionTestBase.scala
+++ b/ast/src/test/scala/org/opencypher/v9_0/ast/semantics/InfixExpressionTestBase.scala
@@ -20,25 +20,25 @@ import org.opencypher.v9_0.util.symbols._
 
 abstract class InfixExpressionTestBase(ctr: (Expression, Expression) => Expression) extends SemanticFunSuite {
 
-  protected def testValidTypes(lhsTypes: TypeSpec, rhsTypes: TypeSpec)(expected: TypeSpec) {
-    val (result, expression) = evaluateWithTypes(lhsTypes, rhsTypes)
+  protected def testValidTypes(lhsTypes: TypeSpec, rhsTypes: TypeSpec, useCypher9ComparisonSemantics: Boolean = false)(expected: TypeSpec) {
+    val (result, expression) = evaluateWithTypes(lhsTypes, rhsTypes, useCypher9ComparisonSemantics)
     result.errors shouldBe empty
     types(expression)(result.state) should equal(expected)
   }
 
-  protected def testInvalidApplication(lhsTypes: TypeSpec, rhsTypes: TypeSpec)(message: String) {
-    val (result, _) = evaluateWithTypes(lhsTypes, rhsTypes)
+  protected def testInvalidApplication(lhsTypes: TypeSpec, rhsTypes: TypeSpec, useCypher9ComparisonSemantics: Boolean = false)(message: String) {
+    val (result, _) = evaluateWithTypes(lhsTypes, rhsTypes, useCypher9ComparisonSemantics)
     result.errors should not be empty
     result.errors.head.msg should equal(message)
   }
 
-  protected def evaluateWithTypes(lhsTypes: TypeSpec, rhsTypes: TypeSpec): (SemanticCheckResult, Expression) = {
+  protected def evaluateWithTypes(lhsTypes: TypeSpec, rhsTypes: TypeSpec, useCypher9ComparisonSemantics: Boolean): (SemanticCheckResult, Expression) = {
     val lhs = DummyExpression(lhsTypes)
     val rhs = DummyExpression(rhsTypes)
 
     val expression = ctr(lhs, rhs)
 
-    val state = SemanticExpressionCheck.simple(Seq(lhs, rhs))(SemanticState.clean).state
+    val state = SemanticExpressionCheck.simple(Seq(lhs, rhs))(SemanticState.clean.withCypher9ComparabilitySemantics(useCypher9ComparisonSemantics)).state
     (SemanticExpressionCheck.simple(expression)(state), expression)
   }
 }

--- a/ast/src/test/scala/org/opencypher/v9_0/ast/semantics/LessThanOrEqualTest.scala
+++ b/ast/src/test/scala/org/opencypher/v9_0/ast/semantics/LessThanOrEqualTest.scala
@@ -15,30 +15,29 @@
  */
 package org.opencypher.v9_0.ast.semantics
 
+import org.opencypher.v9_0.expressions
 import org.opencypher.v9_0.util.DummyPosition
 import org.opencypher.v9_0.util.symbols._
-import org.opencypher.v9_0.expressions
-import org.opencypher.v9_0.expressions.LessThanOrEqual
 
 class LessThanOrEqualTest extends InfixExpressionTestBase(expressions.LessThanOrEqual(_, _)(DummyPosition(0))) {
 
-  test("shouldSupportComparingIntegers") {
+  test("should support comparing integers") {
     testValidTypes(CTInteger, CTInteger)(CTBoolean)
   }
 
-  test("shouldSupportComparingDoubles") {
+  test("should support comparing doubles") {
     testValidTypes(CTFloat, CTFloat)(CTBoolean)
   }
 
-  test("shouldSupportComparingStrings") {
+  test("should support comparing strings") {
     testValidTypes(CTString, CTString)(CTBoolean)
   }
 
-  test("shouldSupportComparingPoints") {
+  test("should support comparing points") {
     testValidTypes(CTPoint, CTPoint)(CTBoolean)
   }
 
-  test("shouldSupportComparingTemporals") {
+  test("should support comparing temporals") {
     testValidTypes(CTDate, CTDate)(CTBoolean)
     testValidTypes(CTTime, CTTime)(CTBoolean)
     testValidTypes(CTLocalTime, CTLocalTime)(CTBoolean)
@@ -46,9 +45,23 @@ class LessThanOrEqualTest extends InfixExpressionTestBase(expressions.LessThanOr
     testValidTypes(CTLocalDateTime, CTLocalDateTime)(CTBoolean)
   }
 
-  test("shouldReturnErrorIfInvalidArgumentTypes") {
-    testInvalidApplication(CTNode, CTInteger)("Type mismatch: expected Float, Integer, Point, String, Date, Time, LocalTime, LocalDateTime or DateTime but was Node")
+  test("should return error if invalid argument types") {
+    testInvalidApplication(CTNode, CTInteger)(
+      "Type mismatch: expected Float, Integer, Point, String, Date, Time, LocalTime, LocalDateTime or DateTime but was Node")
     testInvalidApplication(CTInteger, CTNode)("Type mismatch: expected Float or Integer but was Node")
-    testInvalidApplication(CTDuration, CTDuration)("Type mismatch: expected Float, Integer, Point, String, Date, Time, LocalTime, LocalDateTime or DateTime but was Duration")
+    testInvalidApplication(CTDuration, CTDuration)(
+      "Type mismatch: expected Float, Integer, Point, String, Date, Time, LocalTime, LocalDateTime or DateTime but was Duration")
+  }
+
+  test("should support comparing all types with Cypher 9 comparison semantics") {
+    val types = List(CTList(CTAny), CTInteger, CTFloat, CTNumber, CTNode, CTPath, CTRelationship, CTMap, CTPoint,
+                     CTDate, CTDuration, CTBoolean, CTString, CTDateTime, CTGeometry, CTLocalDateTime, CTLocalTime,
+                     CTTime)
+
+    types.foreach { t1 =>
+      types.foreach { t2 =>
+        testValidTypes(t1, t2, useCypher9ComparisonSemantics = true)(CTBoolean)
+      }
+    }
   }
 }

--- a/ast/src/test/scala/org/opencypher/v9_0/ast/semantics/LessThanTest.scala
+++ b/ast/src/test/scala/org/opencypher/v9_0/ast/semantics/LessThanTest.scala
@@ -15,10 +15,9 @@
  */
 package org.opencypher.v9_0.ast.semantics
 
+import org.opencypher.v9_0.expressions
 import org.opencypher.v9_0.util.DummyPosition
 import org.opencypher.v9_0.util.symbols._
-import org.opencypher.v9_0.expressions
-import org.opencypher.v9_0.expressions.LessThan
 
 class LessThanTest extends InfixExpressionTestBase(expressions.LessThan(_, _)(DummyPosition(0))) {
 
@@ -50,5 +49,17 @@ class LessThanTest extends InfixExpressionTestBase(expressions.LessThan(_, _)(Du
     testInvalidApplication(CTNode, CTInteger)("Type mismatch: expected Float, Integer, Point, String, Date, Time, LocalTime, LocalDateTime or DateTime but was Node")
     testInvalidApplication(CTInteger, CTNode)("Type mismatch: expected Float or Integer but was Node")
     testInvalidApplication(CTDuration, CTDuration)("Type mismatch: expected Float, Integer, Point, String, Date, Time, LocalTime, LocalDateTime or DateTime but was Duration")
+  }
+
+  test("should support comparing all types with Cypher 9 comparison semantics") {
+    val types = List(CTList(CTAny), CTInteger, CTFloat, CTNumber, CTNode, CTPath, CTRelationship, CTMap, CTPoint,
+                     CTDate, CTDuration, CTBoolean, CTString, CTDateTime, CTGeometry, CTLocalDateTime, CTLocalTime,
+                     CTTime)
+
+    types.foreach { t1 =>
+      types.foreach { t2 =>
+        testValidTypes(t1, t2, useCypher9ComparisonSemantics = true)(CTBoolean)
+      }
+    }
   }
 }

--- a/ast/src/test/scala/org/opencypher/v9_0/ast/semantics/NotEqualsTest.scala
+++ b/ast/src/test/scala/org/opencypher/v9_0/ast/semantics/NotEqualsTest.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2002-2018 Neo4j Sweden AB (http://neo4j.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opencypher.v9_0.ast.semantics
+
+import org.opencypher.v9_0.expressions
+import org.opencypher.v9_0.util.DummyPosition
+import org.opencypher.v9_0.util.symbols._
+
+class NotEqualsTest extends InfixExpressionTestBase(expressions.NotEquals(_, _)(DummyPosition(0))) {
+  private val types = List(CTList(CTAny), CTInteger, CTFloat, CTNumber, CTNode, CTPath, CTRelationship, CTMap, CTPoint,
+                   CTDate, CTDuration, CTBoolean, CTString, CTDateTime, CTGeometry, CTLocalDateTime, CTLocalTime, CTTime)
+
+  test("should support equality checks among all types with Cypher 9 comparison semantics") {
+    types.foreach { t1 =>
+      types.foreach { t2 =>
+        testValidTypes(t1, t2, useCypher9ComparisonSemantics = true)(CTBoolean)
+      }
+    }
+  }
+}


### PR DESCRIPTION
According to the [specification](https://github.com/opencypher/openCypher/blob/master/cip/1.accepted/CIP2016-06-14-Define-comparability-and-equality-as-well-as-orderability-and-equivalence.adoc#orderability-equivalence) comparing two values with different types
should be `null` and not throw an error. This PR updates to basically remove
type checking from `>`, `>=`, `<`, and `<=` however in order to be
backwards compatible we only do this if you set
`cypher9ComparisonSemantics` to `true`.