### PR TITLE
Upgrade to Scala 2.13

### DIFF
--- a/ast/pom.xml
+++ b/ast/pom.xml
@@ -8,7 +8,7 @@
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>ast-9.0</artifactId>
+  <artifactId>ast-9.0_2.13</artifactId>
   <packaging>jar</packaging>
   <version>9.0-SNAPSHOT</version>
   <name>openCypher AST for the Cypher Query Language</name>
@@ -53,19 +53,19 @@
 
     <dependency>
       <groupId>org.opencypher</groupId>
-      <artifactId>util-9.0</artifactId>
+      <artifactId>util-9.0_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.opencypher</groupId>
-      <artifactId>expressions-9.0</artifactId>
+      <artifactId>expressions-9.0_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.opencypher</groupId>
-      <artifactId>expressions-9.0</artifactId>
+      <artifactId>expressions-9.0_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
@@ -73,7 +73,7 @@
 
     <dependency>
       <groupId>org.opencypher</groupId>
-      <artifactId>test-util-9.0</artifactId>
+      <artifactId>test-util-9.0_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>

--- a/cypher-macros/pom.xml
+++ b/cypher-macros/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>cypher-macros-9.0</artifactId>
+    <artifactId>cypher-macros-9.0_2.13</artifactId>
     <packaging>jar</packaging>
     <version>9.0-SNAPSHOT</version>
     <name>openCypher Macros</name>
@@ -56,7 +56,7 @@
         <!-- neo4j -->
         <dependency>
             <groupId>org.opencypher</groupId>
-            <artifactId>util-9.0</artifactId>
+            <artifactId>util-9.0_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
         </dependency>
 
@@ -84,7 +84,7 @@
 
         <dependency>
             <groupId>org.opencypher</groupId>
-            <artifactId>test-util-9.0</artifactId>
+            <artifactId>test-util-9.0_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>

--- a/expressions/pom.xml
+++ b/expressions/pom.xml
@@ -8,7 +8,7 @@
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>expressions-9.0</artifactId>
+  <artifactId>expressions-9.0_2.13</artifactId>
   <packaging>jar</packaging>
   <version>9.0-SNAPSHOT</version>
   <name>openCypher Expressions</name>
@@ -70,13 +70,13 @@
 
     <dependency>
       <groupId>org.opencypher</groupId>
-      <artifactId>util-9.0</artifactId>
+      <artifactId>util-9.0_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.opencypher</groupId>
-      <artifactId>test-util-9.0</artifactId>
+      <artifactId>test-util-9.0_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>

--- a/frontend/pom.xml
+++ b/frontend/pom.xml
@@ -8,7 +8,7 @@
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>front-end-9.0</artifactId>
+  <artifactId>front-end-9.0_2.13</artifactId>
   <packaging>jar</packaging>
   <version>9.0-SNAPSHOT</version>
   <name>openCypher Front End</name>
@@ -51,31 +51,31 @@
 
     <dependency>
       <groupId>org.opencypher</groupId>
-      <artifactId>util-9.0</artifactId>
+      <artifactId>util-9.0_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.opencypher</groupId>
-      <artifactId>cypher-macros-9.0</artifactId>
+      <artifactId>cypher-macros-9.0_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.opencypher</groupId>
-      <artifactId>expressions-9.0</artifactId>
+      <artifactId>expressions-9.0_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.opencypher</groupId>
-      <artifactId>rewriting-9.0</artifactId>
+      <artifactId>rewriting-9.0_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.opencypher</groupId>
-      <artifactId>rewriting-9.0</artifactId>
+      <artifactId>rewriting-9.0_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
@@ -85,22 +85,14 @@
 
     <dependency>
       <groupId>org.opencypher</groupId>
-      <artifactId>test-util-9.0</artifactId>
+      <artifactId>test-util-9.0_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.opencypher</groupId>
-      <artifactId>expressions-9.0</artifactId>
-      <version>${project.version}</version>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.opencypher</groupId>
-      <artifactId>ast-9.0</artifactId>
+      <artifactId>expressions-9.0_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
@@ -108,7 +100,15 @@
 
     <dependency>
       <groupId>org.opencypher</groupId>
-      <artifactId>opencypher-cypher-ast-factory-9.0</artifactId>
+      <artifactId>ast-9.0_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.opencypher</groupId>
+      <artifactId>opencypher-cypher-ast-factory-9.0_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
@@ -139,7 +139,7 @@
     <dependency>
       <groupId>com.lihaoyi</groupId>
       <artifactId>pprint_${scala.binary.version}</artifactId>
-      <version>0.5.3</version>
+      <version>0.6.0</version>
       <scope>test</scope>
     </dependency>
 
@@ -148,7 +148,7 @@
     <dependency>
       <groupId>org.parboiled</groupId>
       <artifactId>parboiled-scala_${scala.binary.version}</artifactId>
-      <version>1.2.0</version>
+      <version>${parboiled.version}</version>
     </dependency>
 
     <dependency>

--- a/javacc-parser/pom.xml
+++ b/javacc-parser/pom.xml
@@ -71,20 +71,6 @@
 
     <dependencies>
 
-        <!-- scala -->
-
-        <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-library</artifactId>
-             <version>${scala.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-reflect</artifactId>
-             <version>${scala.version}</version>
-        </dependency>
-
         <!-- shared versions are defined in the parent pom -->
 
         <dependency>

--- a/neo4j-ast-factory/pom.xml
+++ b/neo4j-ast-factory/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>opencypher-cypher-ast-factory-9.0</artifactId>
+    <artifactId>opencypher-cypher-ast-factory-9.0_2.13</artifactId>
     <packaging>jar</packaging>
     <version>9.0-SNAPSHOT</version>
     <name>OpenCypher - OpenCypher AST factory</name>
@@ -37,12 +37,12 @@
 
         <dependency>
             <groupId>org.opencypher</groupId>
-            <artifactId>util-9.0</artifactId>
+            <artifactId>util-9.0_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.opencypher</groupId>
-            <artifactId>ast-9.0</artifactId>
+            <artifactId>ast-9.0_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
@@ -59,7 +59,7 @@
         <!-- test dependencies -->
         <dependency>
             <groupId>org.opencypher</groupId>
-            <artifactId>ast-9.0</artifactId>
+            <artifactId>ast-9.0_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
@@ -67,13 +67,7 @@
 
         <dependency>
             <groupId>org.opencypher</groupId>
-            <artifactId>cypher-javacc-parser-9.0</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.opencypher</groupId>
-            <artifactId>test-util-9.0</artifactId>
+            <artifactId>test-util-9.0_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
@@ -87,7 +81,7 @@
 
         <dependency>
             <groupId>org.opencypher</groupId>
-            <artifactId>tck-api_2.12</artifactId>
+            <artifactId>tck-api_${scala.binary.version}</artifactId>
             <version>${opencypher.version}</version>
             <exclusions>
                 <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -34,10 +34,11 @@
 
   <properties>
     <licensing.prepend.text>ASL-2-header.txt</licensing.prepend.text>
-    <scala.version>2.12.13</scala.version>
-    <scala.binary.version>2.12</scala.binary.version>
-    <scala.test.version>3.0.5</scala.test.version>
+    <scala.version>2.13.8</scala.version>
+    <scala.binary.version>2.13</scala.binary.version>
+    <scala.test.version>3.0.9</scala.test.version>
     <scala.check.version>1.14.0</scala.check.version>
+    <parboiled.version>1.3.1</parboiled.version>
     <opencypher.version>1.0.0-M18</opencypher.version>
     <scala.target.vm>1.8</scala.target.vm>
     <scala.java9.arg/>
@@ -148,8 +149,6 @@
             <scalaVersion>${scala.version}</scalaVersion>
             <scalaCompatVersion>${scala.binary.version}</scalaCompatVersion>
             <args>
-              <arg>-Xmax-classfile-name</arg>
-              <arg>100</arg>
               <arg>-Xlint</arg>
               <arg>-target:jvm-${scala.target.vm}</arg>
               <arg>${scala.java9.arg}</arg>

--- a/rewriting/pom.xml
+++ b/rewriting/pom.xml
@@ -8,7 +8,7 @@
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>rewriting-9.0</artifactId>
+  <artifactId>rewriting-9.0_2.13</artifactId>
   <packaging>jar</packaging>
   <version>9.0-SNAPSHOT</version>
   <name>openCypher Rewriting</name>
@@ -53,26 +53,26 @@
 
     <dependency>
       <groupId>org.opencypher</groupId>
-      <artifactId>util-9.0</artifactId>
+      <artifactId>util-9.0_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.opencypher</groupId>
-      <artifactId>test-util-9.0</artifactId>
+      <artifactId>test-util-9.0_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.opencypher</groupId>
-      <artifactId>ast-9.0</artifactId>
+      <artifactId>ast-9.0_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.opencypher</groupId>
-      <artifactId>ast-9.0</artifactId>
+      <artifactId>ast-9.0_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
@@ -80,13 +80,13 @@
 
     <dependency>
       <groupId>org.opencypher</groupId>
-      <artifactId>expressions-9.0</artifactId>
+      <artifactId>expressions-9.0_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.opencypher</groupId>
-      <artifactId>opencypher-cypher-ast-factory-9.0</artifactId>
+      <artifactId>opencypher-cypher-ast-factory-9.0_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>

--- a/test-util/pom.xml
+++ b/test-util/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>test-util-9.0</artifactId>
+    <artifactId>test-util-9.0_2.13</artifactId>
     <packaging>jar</packaging>
     <version>9.0-SNAPSHOT</version>
     <name>openCypher Test Utils</name>
@@ -70,7 +70,7 @@
         </dependency>
         <dependency>
             <groupId>org.opencypher</groupId>
-            <artifactId>tck-api_2.12</artifactId>
+            <artifactId>tck-api_${scala.binary.version}</artifactId>
             <version>${opencypher.version}</version>
             <exclusions>
                 <exclusion>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -8,7 +8,7 @@
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>util-9.0</artifactId>
+  <artifactId>util-9.0_2.13</artifactId>
   <packaging>jar</packaging>
   <version>9.0-SNAPSHOT</version>
   <name>openCypher Utils</name>
@@ -64,7 +64,7 @@
 
     <dependency>
       <groupId>org.opencypher</groupId>
-      <artifactId>test-util-9.0</artifactId>
+      <artifactId>test-util-9.0_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
Upgrade dependencies to Scala 2.13 compatible versions, depend on Scala
2.13, and add _2.13 suffix to differentiate from Scala 2.12 compatible
  jars.