### PR TITLE
ScalaTest is a test dependency, not a runtime one.

### DIFF
--- a/expressions/LICENSES.txt
+++ b/expressions/LICENSES.txt
@@ -6,10 +6,6 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 Apache Software License, Version 2.0
   Apache Commons Lang
   openCypher Utils
-  Scala Compiler
-  scala-xml
-  scalactic
-  scalatest
 ------------------------------------------------------------------------------
 
                                  Apache License

--- a/expressions/NOTICE.txt
+++ b/expressions/NOTICE.txt
@@ -19,10 +19,6 @@ Third-party licenses
 Apache Software License, Version 2.0
   Apache Commons Lang
   openCypher Utils
-  Scala Compiler
-  scala-xml
-  scalactic
-  scalatest
 
 BSD - Scala License
   Scala Library

--- a/expressions/pom.xml
+++ b/expressions/pom.xml
@@ -55,6 +55,7 @@
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.binary.version}</artifactId>
       <version>${scala.test.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.vintage</groupId>


### PR DESCRIPTION
This had mean anything that depended on "expressions" was also pulling in ScalaTest (and its dependencies) as a compile/runtime dependency.